### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*' # Trigger only when a version tag is pushed (e.g., v1.4.2)
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Fetch all history to properly generate changelogs
+
+      - name: Set up variables
+        id: vars
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "release_name=ZTiAWS $VERSION" >> $GITHUB_OUTPUT
+          # Extract release date in proper format
+          echo "release_date=$(date '+%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Read release notes
+        id: release_notes
+        run: |
+          if [ -f "RELEASE_NOTES.txt" ]; then
+            # Extract content from the RELEASE_NOTES.txt file
+            RELEASE_BODY=$(cat RELEASE_NOTES.txt)
+            # Convert markdown content to GitHub Actions syntax
+            RELEASE_BODY="${RELEASE_BODY//'%'/'%25'}"
+            RELEASE_BODY="${RELEASE_BODY//$'\n'/'%0A'}"
+            RELEASE_BODY="${RELEASE_BODY//$'\r'/'%0D'}"
+            echo "body=$RELEASE_BODY" >> $GITHUB_OUTPUT
+          else
+            echo "body=Release ${{ steps.vars.outputs.tag_version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Validate scripts
+        run: |
+          chmod +x ssm authaws
+          shellcheck -x ssm authaws src/*.sh tests/*.sh || {
+            echo "⚠️ ShellCheck detected issues. Release will continue but please fix these in a future update."
+          }
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.vars.outputs.release_name }}
+          body: ${{ steps.release_notes.outputs.body }}
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to the ZTiAWS project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [v1.4.2] - 2025-05-10
+
+### Added
+- Remote command execution capabilities
+  - New `exec` command to run commands on individual EC2 instances
+  - New `exec-tagged` command to run commands across multiple instances with the same tag
+  - Real-time status updates during command execution
+  - Formatted output display showing both stdout and stderr
+- Enhanced error handling for missing instances and command failures
+
+### Fixed
+- Improved AWS SSO token management with better cache file detection
+- Fixed "base64: invalid input" errors when using exec-tagged command
+- Resolved ShellCheck warnings for improved CI pipeline reliability
+
+## [v1.4.1] - 2025-05-10
+
+### Added
+- Enhanced error handling for access token retrieval in authaws script
+
+### Fixed
+- Improved error messages for SSO configuration issues
+
+## [v1.4.0] - 2025-03-30
+
+### Added
+- Renamed auth script from auth_aws to authaws for better usability
+- Ensured PATH updates with proper commenting and new line handling
+
+## [v1.3.1] - 2025-03-31
+
+### Changed
+- Rebranded repository to ZTiAWS from quickssm
+- Updated documentation, README, and issue templates to reflect new branding
+- Improved installation and troubleshooting guides
+
+## [v1.3.0] - 2025-05-10
+
+### Added
+- Support for running commands on EC2 instances (initially named run_command)
+- Improved tests for the SSM script
+
+### Fixed
+- Syntax error in detect_os function
+- ShellCheck directive placement in cleanup function
+
+## [v1.1.2] - 2025-03-28
+
+### Added
+- New auth_aws script for simplified AWS SSO login
+- Improved logging functionality
+- Better error handling
+
+## [v1.1.0] - 2025-02-06
+
+### Added
+- Support for Singapore region (ap-southeast-1)
+- Formatted EC2 instance output with clear columns
+- PowerShell profile for Windows users
+
+## [v1.0.0] - 2025-01-20 (Initial Release)
+
+### Added
+- Core SSM Session Manager functionality
+- Support for multiple regions
+- Auto-install prompt for AWS SSM plugin
+- Basic documentation and README
+- Installation support for bash and zsh
+- Initial CI/CD setup with badges

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,30 +102,39 @@ Thank you for contributing!
 
 ## 🚀 Releasing a New Version
 
-For maintainers who want to create a new release:
+ZTiAWS now uses an automated release process through GitHub Actions:
 
-```bash
-# Make sure you're on the main branch
-git checkout main
+1. Make sure you're on the main branch
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
 
-# Pull the latest changes (including merged PRs)
-git pull origin main
+2. Ensure all changes are committed and the working directory is clean
+   ```bash
+   git status
+   ```
 
-# Ensure all changes are committed and the working directory is clean
-git status
+3. Update the version numbers in the files:
+   - Update VERSION variable in `ssm` and/or `authaws` scripts
+   - Add a new entry to the top of `CHANGELOG.md`
+   - Update `RELEASE_NOTES.txt` with details for this release
 
-# Create an annotated tag
-git tag -a v1.x.x -m "Version 1.x.x: Brief description of changes"
+4. Commit these version changes
+   ```bash
+   git add ssm authaws CHANGELOG.md RELEASE_NOTES.txt
+   git commit -m "Bump version to vX.Y.Z"
+   ```
 
-# Push the tag to GitHub
-git push origin v1.x.x
-```
+5. Create and push an annotated tag
+   ```bash
+   git tag -a vX.Y.Z -m "Version X.Y.Z: Brief description of changes" 
+   git push origin main vX.Y.Z
+   ```
 
-After pushing the tag, go to the GitHub repository and:
-1. Click on "Releases"
-2. Click "Draft a new release"
-3. Select the tag you just pushed
-4. Add release notes
-5. Publish the release
+6. The GitHub Actions workflow will automatically:
+   - Create a new GitHub release using the tag
+   - Use the content of RELEASE_NOTES.txt as the release description
+   - Validate the scripts using shellcheck
 
-This process ensures that releases are always created from the stable main branch after code has been properly reviewed and merged.
+The automated process ensures that releases are consistent and reduces manual steps needed for creating releases.

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,0 +1,65 @@
+# ZTiAWS v1.4.2 Release Notes
+
+Release Date: May 10, 2025
+
+## SUMMARY
+This release introduces powerful remote command execution capabilities to ZTiAWS, allowing you to run shell commands on EC2 instances directly via the SSM utility. We've also enhanced AWS SSO token management for more reliable authentication.
+
+## NEW FEATURES
+
+### Remote Command Execution via SSM
+The flagship feature of this release lets you execute commands on your EC2 instances without needing to establish a full SSH session:
+
+- New `exec` command for single-instance command execution:
+  ```
+  ssm exec <region> <instance-id> "<command>"
+  ```
+
+- New `exec-tagged` command for multi-instance command execution based on tags:
+  ```
+  ssm exec-tagged <region> <tag-key> <tag-value> "<command>"
+  ```
+
+- Real-time status updates during command execution
+- Comprehensive output formatting showing both stdout and stderr
+- Clear error handling when no matching instances are found
+
+### Enhanced AWS SSO Token Management
+- Improved token cache file detection that matches against your configured SSO_START_URL
+- Better error handling for mismatched or expired tokens
+- Clearer guidance when SSO configuration changes are detected
+
+## BUG FIXES
+- Fixed "base64: invalid input" errors when using exec-tagged command
+- Resolved ShellCheck warnings for improved CI pipeline reliability
+- Enhanced error reporting across all components
+
+## EXAMPLES
+
+Run a command on a single instance:
+```
+ssm exec cac1 i-00ddcf01799e02060 "hostname"
+```
+
+Check disk space on all web servers:
+```
+ssm exec-tagged use1 Role web "df -h"
+```
+
+View system services on all instances in a project:
+```
+ssm exec-tagged cac1 Project GTM "systemctl status nginx"
+```
+
+## INSTALLATION
+
+For new installations, follow our guide at:
+https://github.com/zsoftly/ztiaws/blob/main/docs/INSTALLATION.md
+
+To update from a previous version:
+```
+git pull origin main
+chmod +x ssm authaws
+```
+
+For more information, please refer to the documentation in the docs/ directory.


### PR DESCRIPTION
- Created a new GitHub Actions workflow  
- Triggers when you push a tag that starts with 'v' (like v1.4.2)
- Creates a GitHub release using that tag
- Uses your the RELEASE_NOTES.txt file as the release description
- Runs shellcheck validation on your scripts (but continues with the release even if there are warnings)
- I've updated your CONTRIBUTING.md file with clear instructions for the new release process, showing maintainers how to:
- Update version numbers in the relevant files
- Create and push a tag to trigger the automated release