### PR TITLE
feat: Add instance name resolution support for SSM connections

### DIFF
--- a/src/instance_resolver.sh
+++ b/src/instance_resolver.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Instance Name Resolution Module for ztiaws SSM tool
+
+# Function to resolve instance identifier (name or ID) to instance ID
+resolve_instance_identifier() {
+    local identifier="$1"
+    local region="$2"
+    
+    # Check if it's already a valid instance ID format
+    if [[ "$identifier" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+        # Verify the instance ID exists
+        local instance_check
+        instance_check=$(aws ec2 describe-instances \
+            --region "$region" \
+            --instance-ids "$identifier" \
+            --query 'Reservations[0].Instances[0].InstanceId' \
+            --output text 2>/dev/null)
+        
+        if [[ "$instance_check" == "$identifier" ]]; then
+            echo "$identifier"
+            return 0
+        else
+            log_error "Instance ID '$identifier' not found in region '$region'" >&2
+            return 1
+        fi
+    fi
+    
+    # Search by Name tag
+    log_info "Searching for instance named: $identifier" >&2
+    
+    local instances
+    instances=$(aws ec2 describe-instances \
+        --region "$region" \
+        --filters "Name=tag:Name,Values=$identifier" "Name=instance-state-name,Values=running,stopped" \
+        --query 'Reservations[].Instances[].[InstanceId,Tags[?Key==`Name`].Value|[0]]' \
+        --output json)
+    
+    local count
+    count=$(echo "$instances" | jq length)
+    
+    if [[ "$count" -eq 0 ]]; then
+        log_error "No instance found with name '$identifier'" >&2
+        return 1
+    elif [[ "$count" -eq 1 ]]; then
+        local instance_id
+        instance_id=$(echo "$instances" | jq -r '.[0][0]')
+        log_info "Found: $identifier → $instance_id" >&2
+        echo "$instance_id"
+        return 0
+    else
+        log_error "Multiple instances found with name '$identifier'. Please be more specific." >&2
+        return 1
+    fi
+}
+
+# Function to check if an identifier could be an instance name
+is_potential_instance_name() {
+    local identifier="$1"
+    
+    # If it matches instance ID pattern, it's not a name
+    if [[ "$identifier" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+        return 1
+    fi
+    
+    # If it contains only valid name characters, it could be a name
+    if [[ "$identifier" =~ ^[a-zA-Z0-9._-]+$ ]]; then
+        return 0
+    fi
+    
+    return 1
+}

--- a/src/instance_resolver.sh
+++ b/src/instance_resolver.sh
@@ -32,7 +32,7 @@ resolve_instance_identifier() {
     instances=$(aws ec2 describe-instances \
         --region "$region" \
         --filters "Name=tag:Name,Values=$identifier" "Name=instance-state-name,Values=running,stopped" \
-        --query 'Reservations[].Instances[].[InstanceId,Tags[?Key==`Name`].Value|[0]]' \
+        --query "Reservations[].Instances[].[InstanceId,Tags[?Key==\`Name\`].Value|[0]]" \
         --output json)
     
     local count

--- a/ssm
+++ b/ssm
@@ -214,34 +214,29 @@ validate_instance_identifier() {
     return 1
 }
 # Exec command handler
-# NEW VERSION with name resolution
 handle_exec_command() {
-    # Check if we have all required arguments
     if [ $# -lt 3 ]; then
         log_error "Missing required parameters for exec command"
-        echo "Usage: ssm exec <region> <instance-identifier> \"<command>\""  # ← Changed text
+        echo "Usage: ssm exec <region> <instance-identifier> \"<command>\""
         exit 1
     fi
 
     local region_code="$1"
-    local instance_identifier="$2"  # ← Changed variable name (could be ID or name)
+    local instance_identifier="$2"
     local command="$3"
 
-    # Convert region code to AWS region name
     local region
     region=$(get_region "$region_code")
-    if ! get_region "$region_code" >/dev/null; then  # ← Fixed shellcheck issue
+    if ! get_region "$region_code" >/dev/null; then
         log_error "Invalid region code: $region_code"
         exit 1
     fi
 
-    # NEW: Validate instance identifier format
     if ! is_valid_instance_identifier "$instance_identifier"; then
         log_error "Invalid instance identifier: $instance_identifier"
         exit 1
     fi
 
-    # NEW: Resolve instance identifier to instance ID
     log_info "Resolving instance identifier: $instance_identifier"
     if ! instance_id=$(resolve_instance_identifier "$instance_identifier" "$region"); then
     
@@ -250,7 +245,6 @@ handle_exec_command() {
 
     log_info "Executing command on instance: $instance_id ($instance_identifier)"
     
-    # Uses the resolved instance ID (same as before)
     run_remote_command "$instance_id" "$region" "$command"
     return $?
 }

--- a/ssm
+++ b/ssm
@@ -87,6 +87,7 @@ Examples:
   ssm use1 i-1234                      # Connect to instance in US East
   ssm i-1234                           # Connect to instance in Canada Central
   ssm exec cac1 i-1234 "systemctl status nginx"   # Run command on instance
+  ssm exec cac1 web-server-prod "systemctl status nginx"  # Run command using instance name
   ssm exec-tagged use1 Role web "df -h" # Run command on instances with tag Role=web
 EOF
 }
@@ -213,62 +214,47 @@ validate_instance_identifier() {
     return 1
 }
 # Exec command handler
+# NEW VERSION with name resolution
 handle_exec_command() {
     # Check if we have all required arguments
     if [ $# -lt 3 ]; then
         log_error "Missing required parameters for exec command"
-        echo "Usage: ssm exec <region> <instance-id> \"<command>\""
+        echo "Usage: ssm exec <region> <instance-identifier> \"<command>\""  # ← Changed text
         exit 1
     fi
 
     local region_code="$1"
-    local instance_id="$2"
+    local instance_identifier="$2"  # ← Changed variable name (could be ID or name)
     local command="$3"
-    
+
     # Convert region code to AWS region name
     local region
     region=$(get_region "$region_code")
-    if [ "$region" = "invalid" ]; then
+    if ! get_region "$region_code" >/dev/null; then  # ← Fixed shellcheck issue
         log_error "Invalid region code: $region_code"
         exit 1
     fi
-    
-    # Validate instance ID
-    if ! validate_instance_identifier "$instance_id"; then
+
+    # NEW: Validate instance identifier format
+    if ! is_valid_instance_identifier "$instance_identifier"; then
+        log_error "Invalid instance identifier: $instance_identifier"
         exit 1
     fi
+
+    # NEW: Resolve instance identifier to instance ID
+    log_info "Resolving instance identifier: $instance_identifier"
+    if ! instance_id=$(resolve_instance_identifier "$instance_identifier" "$region"); then
     
-    # Run the command
+        exit 1
+    fi
+
+    log_info "Executing command on instance: $instance_id ($instance_identifier)"
+    
+    # Uses the resolved instance ID (same as before)
     run_remote_command "$instance_id" "$region" "$command"
     return $?
 }
 
-# Run command by tag handler
-handle_exec_tagged_command() {
-    # Check if we have all required arguments
-    if [ $# -lt 4 ]; then
-        log_error "Missing required parameters for exec-tagged command"
-        echo "Usage: ssm exec-tagged <region> <tag-key> <tag-value> \"<command>\""
-        exit 1
-    fi
-
-    local region_code="$1"
-    local tag_key="$2"
-    local tag_value="$3"
-    local command="$4"
-    
-    # Convert region code to AWS region name
-    local region
-    region=$(get_region "$region_code")
-    if [ "$region" = "invalid" ]; then
-        log_error "Invalid region code: $region_code"
-        exit 1
-    fi
-    
-    # Run the command by tag
-    run_remote_command_tagged "$tag_key" "$tag_value" "$region" "$command"
-    return $?
-}
 
 # Main logic
 main() {

--- a/ssm
+++ b/ssm
@@ -52,7 +52,10 @@ else
     echo "Error: Could not find src/run_command.sh in either ${SCRIPT_DIR}/src/ or /usr/local/bin/src/" >&2
     exit 1
 fi
-
+# Import instance resolver functions
+if [ -f "${SCRIPT_DIR}/src/instance_resolver.sh" ]; then
+    source "${SCRIPT_DIR}/src/instance_resolver.sh"
+fi
 # Function to show usage
 usage() {
     cat << EOF
@@ -193,14 +196,22 @@ install_ssm_plugin() {
 REGION="ca-central-1"
 
 # Validate instance ID format
-validate_instance_id() {
-    if ! [[ $1 =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
-        log_error "Invalid instance ID format. Should be i-xxxxxxxx"
-        return 1
+validate_instance_identifier() {
+    local identifier="$1"
+    
+    # If it looks like an instance ID, validate the format
+    if [[ "$identifier" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+        return 0
     fi
-    return 0
+    
+    # If it could be an instance name, allow it
+    if is_potential_instance_name "$identifier"; then
+        return 0
+    fi
+    
+    log_error "Invalid instance identifier format. Should be instance ID (i-xxxxxxxx) or instance name"
+    return 1
 }
-
 # Exec command handler
 handle_exec_command() {
     # Check if we have all required arguments
@@ -223,7 +234,7 @@ handle_exec_command() {
     fi
     
     # Validate instance ID
-    if ! validate_instance_id "$instance_id"; then
+    if ! validate_instance_identifier "$instance_id"; then
         exit 1
     fi
     
@@ -325,32 +336,42 @@ main() {
                 --output table
             echo -e "\nUsage: ssm $1 <instance-id>"
         else
-            if ! validate_instance_id "$1"; then
+            if ! validate_instance_identifier "$1"; then
                 exit 1
-            fi
-            log_info "Connecting to instance $1 in $REGION..."
-            aws ssm start-session \
-                --region "$REGION" \
-                --target "$1"
-        fi
-    elif [ $# -eq 2 ]; then
-        REGION=$(get_region "$1")
-        if [ "$REGION" = "invalid" ]; then
-            log_error "Invalid region. Use cac1, caw1, usw1, use1, or euw1"
-            usage
-            exit 1
-        fi
-        if ! validate_instance_id "$2"; then
-            exit 1
-        fi
-        log_info "Connecting to instance $2 in $REGION..."
+      fi
+        log_info "Connecting to instance $1 in $REGION..."
         aws ssm start-session \
             --region "$REGION" \
-            --target "$2"
-    else
+            --target "$1"
+    fi
+elif [ $# -eq 2 ]; then
+    REGION=$(get_region "$1")
+    if [ "$REGION" = "invalid" ]; then
+        log_error "Invalid region. Use cac1, caw1, usw1, use1, or euw1"
         usage
         exit 1
     fi
+    if ! validate_instance_identifier "$2"; then
+        exit 1
+    fi
+    
+    # Resolve instance name to ID if needed
+    local instance_id="$2"
+    if ! [[ "$2" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+        instance_id=$(resolve_instance_identifier "$2" "$REGION")
+        if [ $? -ne 0 ]; then
+            exit 1
+        fi
+    fi
+
+    log_info "Connecting to instance $instance_id in $REGION..."
+    aws ssm start-session \
+        --region "$REGION" \
+        --target "$instance_id"
+else
+    usage
+    exit 1
+fi
 }
 
 # Run main function

--- a/ssm
+++ b/ssm
@@ -232,8 +232,7 @@ handle_exec_command() {
         exit 1
     fi
 
-    if ! is_valid_instance_identifier "$instance_identifier"; then
-        log_error "Invalid instance identifier: $instance_identifier"
+    if ! validate_instance_identifier "$instance_identifier"; then
         exit 1
     fi
 
@@ -249,6 +248,31 @@ handle_exec_command() {
     return $?
 }
 
+# Exec-tagged command handler
+handle_exec_tagged_command() {
+    if [ $# -lt 4 ]; then
+        log_error "Missing required parameters for exec-tagged command"
+        echo "Usage: ssm exec-tagged <region> <tag-key> <tag-value> \"<command>\""
+        exit 1
+    fi
+
+    local region_code="$1"
+    local tag_key="$2"
+    local tag_value="$3"
+    local command="$4"
+
+    local region
+    region=$(get_region "$region_code")
+    if ! get_region "$region_code" >/dev/null; then
+        log_error "Invalid region code: $region_code"
+        exit 1
+    fi
+
+    log_info "Executing command on instances with tag $tag_key=$tag_value in region $region"
+    
+    run_remote_command_tagged "$tag_key" "$tag_value" "$region" "$command"
+    return $?
+}
 
 # Main logic
 main() {
@@ -318,12 +342,22 @@ main() {
         else
             if ! validate_instance_identifier "$1"; then
                 exit 1
-      fi
-        log_info "Connecting to instance $1 in $REGION..."
-        aws ssm start-session \
-            --region "$REGION" \
-            --target "$1"
-    fi
+            fi
+            
+            # Resolve instance name to ID if needed
+            local instance_id="$1"
+            if ! [[ "$1" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+                instance_id=$(resolve_instance_identifier "$1" "$REGION")
+                if ! [[ "$instance_id" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+                    exit 1
+                fi
+            fi
+            
+            log_info "Connecting to instance $instance_id in $REGION..."
+            aws ssm start-session \
+                --region "$REGION" \
+                --target "$instance_id"
+        fi
 elif [ $# -eq 2 ]; then
     REGION=$(get_region "$1")
     if [ "$REGION" = "invalid" ]; then

--- a/ssm
+++ b/ssm
@@ -359,7 +359,7 @@ elif [ $# -eq 2 ]; then
     local instance_id="$2"
     if ! [[ "$2" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
         instance_id=$(resolve_instance_identifier "$2" "$REGION")
-        if [ $? -ne 0 ]; then
+        if ! some_command; then
             exit 1
         fi
     fi

--- a/ssm
+++ b/ssm
@@ -338,11 +338,11 @@ elif [ $# -eq 2 ]; then
     # Resolve instance name to ID if needed
     local instance_id="$2"
     if ! [[ "$2" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
-        instance_id=$(resolve_instance_identifier "$2" "$REGION")
-        if ! some_command; then
-            exit 1
-        fi
+    instance_id=$(resolve_instance_identifier "$2" "$REGION")
+    if ! [[ "$instance_id" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+        exit 1
     fi
+fi
 
     log_info "Connecting to instance $instance_id in $REGION..."
     aws ssm start-session \

--- a/tests/QA_AUTHAWS_TESTS.md
+++ b/tests/QA_AUTHAWS_TESTS.md
@@ -1,0 +1,93 @@
+# QA AuthAWS Test Scenarios
+
+**Prerequisites:** AWS CLI installed, fzf installed, jq installed, valid AWS SSO setup.
+
+**Setup:** Navigate to your local ztiaws directory, switch to the feature branch, use `./authaws` for all commands below.
+
+Replace `your-profile-name` with actual profile names from your environment.
+
+**Testing different profiles:** Use different profile names. **Testing different accounts:** Select different accounts/roles during interactive setup.
+
+## Basic Commands
+```bash
+./authaws help                    # Shows help
+./authaws version                 # Shows version
+./authaws check                   # Verifies requirements
+```
+
+## Profile Authentication
+```bash
+# Default profile (from .env file)
+./authaws                         # Uses default profile from .env
+
+# Specific profile
+./authaws dev-profile             # Authenticates with specific profile
+./authaws prod-profile            # Authenticates with different profile
+./authaws my-test-profile         # Creates new profile if needed
+```
+
+## Credential Management
+```bash
+# Show credentials for profiles
+./authaws creds                   # Shows creds for current/default profile
+./authaws creds dev-profile       # Shows creds for specific profile
+./authaws creds nonexistent       # Profile not found error
+```
+
+## Interactive Flows
+```bash
+# These require interactive selection via fzf
+./authaws new-profile             # Should show account selection
+# Select account -> Select role -> Profile configured
+
+./authaws                         # With expired session
+# Should prompt for re-authentication
+```
+
+## Configuration Setup
+```bash
+# First time setup (when no .env exists)
+./authaws                         # Should offer to create .env file
+# Answer 'y' -> Creates sample .env -> Shows edit instructions
+```
+
+## Error Cases
+```bash
+./authaws invalid-command         # Shows help
+./authaws creds                   # Without valid session - should show instructions
+```
+
+## Environment Testing
+```bash
+# Test with missing dependencies (temporarily rename)
+# mv $(which fzf) $(which fzf).bak
+# ./authaws check                 # Should show missing fzf error
+# mv $(which fzf).bak $(which fzf)
+
+# Test with no .env file
+# mv .env .env.bak
+# ./authaws                       # Should offer to create .env
+# mv .env.bak .env
+```
+
+## QA Checklist
+- [ ] Basic commands work
+- [ ] Authentication flows work
+- [ ] Credential display works
+- [ ] Interactive account/role selection works
+- [ ] Profile creation works
+- [ ] Configuration setup works
+- [ ] Error handling is clear
+- [ ] Dependencies are checked
+- [ ] No regressions
+
+## New Features (Developers add here)
+When adding new features, developers must:
+1. Add test commands below showing the new functionality
+2. Test that existing core features (auth, creds, profiles) still work with the new feature
+3. Run full end-to-end testing to ensure no regressions
+
+```bash
+# Add new test commands when implementing features
+# Example: ./authaws new-command profile-name
+```

--- a/tests/QA_SSM_TESTS.md
+++ b/tests/QA_SSM_TESTS.md
@@ -1,0 +1,79 @@
+# QA Test Scenarios
+
+**Prerequisites:** AWS CLI configured, EC2 instances in ca-central-1, SSM agent installed on instances.
+
+**Setup:** Navigate to your local ztiaws directory, switch to the feature branch, use `./ssm` for all commands below.
+
+Replace `i-1234567890abcdef0` with real instance ID and `web-server` with real instance name.
+
+**Testing other regions:** Replace `cac1` with `use1`, `usw2`, etc. **Testing multiple instances:** Use different instance names/IDs in same region.
+
+## Basic Commands
+```bash
+./ssm help                     # Shows help
+./ssm version                  # Shows version
+./ssm check                    # Verifies requirements
+```
+
+## Instance Listing
+```bash
+./ssm cac1                     # Lists instances
+./ssm xyz1                     # Invalid region error
+```
+
+## Connect to Instance
+```bash
+# Using Instance ID
+./ssm cac1 i-1234567890abcdef0 # Connects via SSM
+./ssm cac1 i-123               # Invalid ID error
+
+# Using Instance Name (NEW)
+./ssm cac1 web-server          # Resolves name and connects
+./ssm cac1 fake-name           # Instance not found error
+```
+
+## Execute Commands
+```bash
+# Using Instance ID
+./ssm exec cac1 i-1234567890abcdef0 'hostname'  # Runs command
+./ssm exec cac1 i-123 'ls'                      # Invalid ID error
+
+# Using Instance Name (NEW)
+./ssm exec cac1 web-server 'hostname'           # Resolves and runs command
+./ssm exec cac1 fake-name 'ls'                  # Instance not found
+```
+
+## Tagged Execution
+```bash
+./ssm exec-tagged cac1 Environment prod 'hostname'  # Runs on tagged instances
+./ssm exec-tagged cac1 Role                         # Missing parameters
+```
+
+## Error Cases
+```bash
+./ssm invalid-command                    # Shows help
+./ssm exec cac1                          # Missing parameters
+./ssm exec cac1 web-server               # Missing command
+```
+
+## QA Checklist
+- [ ] Basic commands work
+- [ ] Instance listing works
+- [ ] Connect with Instance ID works
+- [ ] Connect with instance name works (NEW)
+- [ ] Exec with Instance ID works  
+- [ ] Exec with instance name works (NEW)
+- [ ] Tagged execution works
+- [ ] Error handling is clear
+- [ ] No regressions
+
+## New Features (Developers add here)
+When adding new features, developers must:
+1. Add test commands below showing the new functionality
+2. Test that existing core features (connect, exec, exec-tagged) still work with the new feature
+3. Run full end-to-end testing to ensure no regressions
+
+```bash
+# Add new test commands when implementing features
+# Example: ./ssm new-command cac1 web-server 'test'
+```


### PR DESCRIPTION
 Added resolve_instance_identifier function to resolve names to IDs
- Updated ssm script to handle both instance IDs and names
- Added validation for instance identifiers
- Users can now connect using: ./ssm use1 server-name