### PR TITLE
feat: Enhance S3 permissions management and IAM validation 

### DIFF
--- a/src/04_ssm_file_transfer.sh
+++ b/src/04_ssm_file_transfer.sh
@@ -7,10 +7,11 @@
 # Security and Configuration Notes:
 # - Policy names use unique identifiers (timestamp + hostname + random) instead of PIDs
 # - Temporary policy files use secure permissions (600) and proper temp directories
-# - IAM propagation delays are configurable via environment variables:
-#   - IAM_PROPAGATION_DELAY: Initial delay (default: 5 seconds)
-#   - IAM_PROPAGATION_MAX_WAIT: Maximum wait time (default: 60 seconds)
+# - IAM propagation delay is configurable via environment variable:
+#   - IAM_PROPAGATION_DELAY: Delay for IAM changes to propagate (default: 5 seconds)
 # - Emergency cleanup uses robust pattern matching for instance ID extraction
+# - Filesystem locking prevents concurrent IAM policy operations on the same instance
+# - Locks are automatically cleaned up and include stale lock detection (5 minute timeout)
 
 # File size threshold for choosing transfer method (1MB)
 FILE_SIZE_THRESHOLD=$((1024 * 1024))
@@ -23,9 +24,17 @@ S3_BUCKET_PREFIX="ztiaws-ssm-file-transfer"
 # No default value - region must be explicitly provided
 CURRENT_REGION=""
 
-# Configuration for IAM propagation wait times
+# Configuration for IAM propagation wait time
 IAM_PROPAGATION_DELAY="${IAM_PROPAGATION_DELAY:-5}"  # Default 5 seconds
-IAM_PROPAGATION_MAX_WAIT="${IAM_PROPAGATION_MAX_WAIT:-60}"  # Maximum 60 seconds
+
+# Lock directory for preventing concurrent policy operations on the same instance
+LOCK_DIR="/tmp/ztiaws-locks"
+
+# Dedicated directory for ztiaws temporary files to avoid scanning entire /tmp
+ZTIAWS_TEMP_DIR="/tmp/ztiaws-temp"
+
+# Registry file to track active policies for efficient cleanup
+POLICY_REGISTRY_FILE="${ZTIAWS_TEMP_DIR}/policy-registry"
 
 # Generate a unique identifier for policy names and temp files
 # Combines timestamp, hostname, and random number for uniqueness
@@ -36,35 +45,253 @@ generate_unique_id() {
     echo "${timestamp}-${hostname}-${random}"
 }
 
+# Initialize the ztiaws temporary directory and registry
+init_temp_directory() {
+    # Ensure ztiaws temp directory exists with proper permissions
+    if ! mkdir -p "$ZTIAWS_TEMP_DIR" 2>/dev/null; then
+        log_warn "Could not create ztiaws temp directory: $ZTIAWS_TEMP_DIR"
+        return 1
+    fi
+    chmod 700 "$ZTIAWS_TEMP_DIR" 2>/dev/null || true
+    
+    # Ensure lock directory exists
+    mkdir -p "$LOCK_DIR" 2>/dev/null || true
+    
+    # Initialize registry file if it doesn't exist
+    if [[ ! -f "$POLICY_REGISTRY_FILE" ]]; then
+        touch "$POLICY_REGISTRY_FILE"
+        chmod 600 "$POLICY_REGISTRY_FILE" 2>/dev/null || true
+    fi
+    
+    return 0
+}
+
+# Add a policy to the registry
+# Format: instance_id|region|policy_arn|policy_file|timestamp
+add_policy_to_registry() {
+    local instance_id="$1"
+    local region="$2"
+    local policy_arn="$3"
+    local policy_file="$4"
+    local timestamp=$(date +%s)
+    
+    init_temp_directory || return 1
+    
+    # Use a lock file to prevent concurrent registry modifications
+    local registry_lock="${ZTIAWS_TEMP_DIR}/.registry.lock"
+    local lock_acquired=false
+    local attempts=0
+    local max_attempts=10
+    
+    while [ $attempts -lt $max_attempts ]; do
+        if mkdir "$registry_lock" 2>/dev/null; then
+            lock_acquired=true
+            break
+        fi
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+    
+    if [[ "$lock_acquired" == "true" ]]; then
+        echo "${instance_id}|${region}|${policy_arn}|${policy_file}|${timestamp}" >> "$POLICY_REGISTRY_FILE"
+        rmdir "$registry_lock" 2>/dev/null || true
+        debug_log "Added policy to registry: $policy_arn for instance $instance_id"
+        return 0
+    else
+        log_warn "Failed to acquire registry lock for adding policy"
+        return 1
+    fi
+}
+
+# Remove policies from registry for a specific instance
+remove_policies_from_registry() {
+    local instance_id="$1"
+    
+    init_temp_directory || return 1
+    
+    # Use a lock file to prevent concurrent registry modifications
+    local registry_lock="${ZTIAWS_TEMP_DIR}/.registry.lock"
+    local lock_acquired=false
+    local attempts=0
+    local max_attempts=10
+    
+    while [ $attempts -lt $max_attempts ]; do
+        if mkdir "$registry_lock" 2>/dev/null; then
+            lock_acquired=true
+            break
+        fi
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+    
+    if [[ "$lock_acquired" == "true" ]]; then
+        # Create a temporary file with entries not matching the instance_id
+        local temp_registry="${ZTIAWS_TEMP_DIR}/.registry.tmp"
+        if [[ -f "$POLICY_REGISTRY_FILE" ]]; then
+            grep -v "^${instance_id}|" "$POLICY_REGISTRY_FILE" > "$temp_registry" 2>/dev/null || true
+            mv "$temp_registry" "$POLICY_REGISTRY_FILE"
+        fi
+        rmdir "$registry_lock" 2>/dev/null || true
+        debug_log "Removed policies from registry for instance: $instance_id"
+        return 0
+    else
+        log_warn "Failed to acquire registry lock for removing policies"
+        return 1
+    fi
+}
+
+# Get policies for a specific instance from registry
+get_policies_for_instance() {
+    local instance_id="$1"
+    
+    if [[ -f "$POLICY_REGISTRY_FILE" ]]; then
+        grep "^${instance_id}|" "$POLICY_REGISTRY_FILE" 2>/dev/null || true
+    fi
+}
+
+# Clean up stale registry entries (older than 24 hours)
+cleanup_stale_registry_entries() {
+    init_temp_directory || return 1
+    
+    local registry_lock="${ZTIAWS_TEMP_DIR}/.registry.lock"
+    local lock_acquired=false
+    local attempts=0
+    local max_attempts=10
+    
+    while [ $attempts -lt $max_attempts ]; do
+        if mkdir "$registry_lock" 2>/dev/null; then
+            lock_acquired=true
+            break
+        fi
+        sleep 0.1
+        attempts=$((attempts + 1))
+    done
+    
+    if [[ "$lock_acquired" == "true" ]]; then
+        if [[ -f "$POLICY_REGISTRY_FILE" ]]; then
+            local current_time=$(date +%s)
+            local temp_registry="${ZTIAWS_TEMP_DIR}/.registry.tmp"
+            local cleaned_entries=0
+            
+            while IFS='|' read -r instance_id region policy_arn policy_file timestamp; do
+                # Skip empty lines
+                [[ -z "$instance_id" ]] && continue
+                
+                # Check if entry is older than 24 hours (86400 seconds)
+                local age=$((current_time - timestamp))
+                if [ $age -gt 86400 ]; then
+                    debug_log "Removing stale registry entry for instance $instance_id (age: ${age}s)"
+                    # Clean up associated policy file if it exists
+                    [[ -f "$policy_file" ]] && rm -f "$policy_file"
+                    ((cleaned_entries++))
+                else
+                    # Keep this entry
+                    echo "${instance_id}|${region}|${policy_arn}|${policy_file}|${timestamp}" >> "$temp_registry"
+                fi
+            done < "$POLICY_REGISTRY_FILE"
+            
+            # Replace registry with cleaned version
+            if [[ -f "$temp_registry" ]]; then
+                mv "$temp_registry" "$POLICY_REGISTRY_FILE"
+            else
+                # No entries left, create empty registry
+                : > "$POLICY_REGISTRY_FILE"
+            fi
+            
+            if [ $cleaned_entries -gt 0 ]; then
+                debug_log "Cleaned up $cleaned_entries stale registry entries"
+            fi
+        fi
+        rmdir "$registry_lock" 2>/dev/null || true
+        return 0
+    else
+        log_warn "Failed to acquire registry lock for cleanup"
+        return 1
+    fi
+}
+
 # Create a secure temporary file for storing policy ARNs
 # Returns the path to the temporary file with restricted permissions
 create_secure_temp_file() {
     local prefix="$1"
     local temp_file
     
-    # Create a temporary file with restricted permissions (600)
-    temp_file=$(mktemp -t "${prefix}.XXXXXX")
+    # Ensure ztiaws temp directory exists
+    mkdir -p "$ZTIAWS_TEMP_DIR" 2>/dev/null || true
+    chmod 700 "$ZTIAWS_TEMP_DIR" 2>/dev/null || true
+    
+    # Create a temporary file with restricted permissions (600) in our dedicated directory
+    temp_file=$(mktemp -p "$ZTIAWS_TEMP_DIR" "${prefix}.XXXXXX")
     chmod 600 "$temp_file"
     echo "$temp_file"
 }
 
-# Wait for IAM changes to propagate with retry mechanism
+# Acquire a lock for IAM operations on a specific instance
+# Uses filesystem locking to prevent concurrent policy modifications
+acquire_instance_lock() {
+    local instance_id="$1"
+    local lock_file="${LOCK_DIR}/iam-${instance_id}.lock"
+    local max_wait=30  # Maximum wait time for lock acquisition
+    local wait_interval=1
+    local elapsed=0
+    
+    # Ensure lock directory exists
+    mkdir -p "$LOCK_DIR" 2>/dev/null || true
+    
+    debug_log "Attempting to acquire IAM lock for instance: $instance_id"
+    
+    # Try to acquire lock with timeout
+    while [ $elapsed -lt $max_wait ]; do
+        # Use mkdir as an atomic operation for locking
+        if mkdir "$lock_file" 2>/dev/null; then
+            debug_log "Acquired IAM lock for instance: $instance_id"
+            echo "$lock_file"
+            return 0
+        fi
+        
+        sleep $wait_interval
+        elapsed=$((elapsed + wait_interval))
+        
+        # Check if lock is stale (older than 5 minutes)
+        if [ -d "$lock_file" ]; then
+            local lock_age
+            if lock_age=$(stat -c %Y "$lock_file" 2>/dev/null); then
+                local current_time=$(date +%s)
+                local age_seconds=$((current_time - lock_age))
+                
+                if [ $age_seconds -gt 300 ]; then  # 5 minutes
+                    debug_log "Removing stale lock for instance: $instance_id (age: ${age_seconds}s)"
+                    rmdir "$lock_file" 2>/dev/null || true
+                fi
+            fi
+        fi
+    done
+    
+    log_warn "Failed to acquire IAM lock for instance $instance_id within ${max_wait} seconds"
+    return 1
+}
+
+# Release a lock for IAM operations on a specific instance
+release_instance_lock() {
+    local lock_file="$1"
+    
+    if [ -n "$lock_file" ] && [ -d "$lock_file" ]; then
+        if rmdir "$lock_file" 2>/dev/null; then
+            debug_log "Released IAM lock: $(basename "$lock_file")"
+        else
+            log_warn "Failed to release IAM lock: $lock_file"
+        fi
+    fi
+}
+
+# Wait for IAM changes to propagate
+# Currently just waits for the configured delay time
+# TODO: Implement actual IAM propagation validation in future versions
 wait_for_iam_propagation() {
     local delay="${IAM_PROPAGATION_DELAY}"
-    local max_attempts=$((IAM_PROPAGATION_MAX_WAIT / delay))
-    local attempt=1
     
-    debug_log "Waiting for IAM changes to propagate (delay: ${delay}s, max: ${IAM_PROPAGATION_MAX_WAIT}s)"
-    
-    while [ $attempt -le $max_attempts ]; do
-        sleep "$delay"
-        debug_log "IAM propagation wait: ${attempt}/${max_attempts} (${delay}s)"
-        attempt=$((attempt + 1))
-        
-        # For now, we'll just wait the configured time
-        # In future versions, this could include actual validation
-        break
-    done
+    debug_log "Waiting for IAM changes to propagate (${delay}s)"
+    sleep "$delay"
 }
 
 # Set up cleanup trap for emergency situations
@@ -96,6 +323,9 @@ cleanup_on_exit() {
 
 # Set trap for cleanup on script exit
 trap cleanup_on_exit EXIT INT TERM
+
+# Initialize temp directory and registry on script load
+init_temp_directory >/dev/null 2>&1 || true
 
 # Function to set the current region (can be called by main script)
 # This is optional - the region will be set automatically when upload_file/download_file are called
@@ -401,7 +631,7 @@ create_s3_policy_document() {
 EOF
 }
 
-# Attach S3 permissions to instance profile role (background operation)
+# Attach S3 permissions to instance profile role (with locking)
 attach_s3_permissions() {
     local instance_id="$1"
     local region="$2"
@@ -409,9 +639,17 @@ attach_s3_permissions() {
 
     debug_log "Attaching S3 permissions for bucket: $bucket_name"
 
+    # Acquire lock for this instance to prevent concurrent policy modifications
+    local lock_file
+    if ! lock_file=$(acquire_instance_lock "$instance_id"); then
+        log_error "Failed to acquire lock for IAM operations on instance $instance_id"
+        return 1
+    fi
+
     # Get the role name
     local role_name
     if ! role_name=$(get_instance_profile_role "$instance_id" "$region"); then
+        release_instance_lock "$lock_file"
         return 1
     fi
 
@@ -422,9 +660,9 @@ attach_s3_permissions() {
     unique_id=$(generate_unique_id)
     local policy_name="ZTIaws-SSM-S3-Access-${unique_id}"
     
-    # Create policy document
+    # Create policy document with secure permissions
     local policy_file
-    policy_file=$(mktemp)
+    policy_file=$(create_secure_temp_file "ztiaws-s3-policy-doc")
     create_s3_policy_document "$bucket_name" "$policy_file"
 
     # Create and attach the policy
@@ -448,78 +686,104 @@ attach_s3_permissions() {
             local policy_tracking_file
             policy_tracking_file=$(create_secure_temp_file "ztiaws-s3-policy-${instance_id}-${unique_id}")
             echo "$policy_arn" > "$policy_tracking_file"
+            
+            # Add to registry for efficient cleanup
+            add_policy_to_registry "$instance_id" "$region" "$policy_arn" "$policy_tracking_file"
+            
             rm -f "$policy_file"
+            
+            # Release lock before returning
+            release_instance_lock "$lock_file"
             return 0
         else
             log_error "Failed to attach policy to role"
             # Clean up policy if attachment failed
             aws iam delete-policy --policy-arn "$policy_arn" >/dev/null 2>&1
             rm -f "$policy_file"
+            release_instance_lock "$lock_file"
             return 1
         fi
     else
         log_error "Failed to create S3 policy"
         rm -f "$policy_file"
+        release_instance_lock "$lock_file"
         return 1
     fi
 }
 
-# Remove S3 permissions from instance profile role (cleanup operation)
+# Remove S3 permissions from instance profile role (with locking)
 remove_s3_permissions() {
     local instance_id="$1"
     local region="$2"
 
     debug_log "Removing S3 permissions for instance: $instance_id"
 
-    # Find policy files for this instance using a more robust pattern
-    local policy_files
-    policy_files=$(find /tmp -name "ztiaws-s3-policy-${instance_id}-*" -type f 2>/dev/null || true)
+    # Acquire lock for this instance to prevent concurrent policy modifications
+    local lock_file
+    if ! lock_file=$(acquire_instance_lock "$instance_id"); then
+        log_warn "Failed to acquire lock for IAM cleanup on instance $instance_id - skipping cleanup"
+        return 1
+    fi
+
+    # Get policies for this instance from registry
+    local policy_entries
+    policy_entries=$(get_policies_for_instance "$instance_id")
     
-    if [[ -z "$policy_files" ]]; then
-        debug_log "No policy files found for cleanup for instance: $instance_id"
+    if [[ -z "$policy_entries" ]]; then
+        debug_log "No policy entries found in registry for instance: $instance_id"
+        release_instance_lock "$lock_file"
         return 0
     fi
 
-    # Process each policy file found
-    while IFS= read -r policy_file; do
+    # Process each policy entry found in registry
+    while IFS='|' read -r reg_instance_id reg_region policy_arn policy_file timestamp; do
+        # Skip empty lines
+        [[ -z "$reg_instance_id" ]] && continue
+        
+        debug_log "Processing policy from registry: $policy_arn"
+        
+        # Clean up the policy file
         if [[ -f "$policy_file" ]]; then
-            local policy_arn
-            policy_arn=$(cat "$policy_file" 2>/dev/null)
             rm -f "$policy_file"
+        fi
 
-            if [[ -z "$policy_arn" ]]; then
-                debug_log "No policy ARN found in file: $policy_file"
-                continue
-            fi
+        if [[ -z "$policy_arn" ]]; then
+            debug_log "No policy ARN found in registry entry"
+            continue
+        fi
 
-            # Get the role name
-            local role_name
-            if ! role_name=$(get_instance_profile_role "$instance_id" "$region"); then
-                debug_log "Could not get role name for cleanup, but continuing with policy deletion"
+        # Get the role name
+        local role_name
+        if ! role_name=$(get_instance_profile_role "$instance_id" "$region"); then
+            debug_log "Could not get role name for cleanup, but continuing with policy deletion"
+        else
+            # Detach policy from role
+            if aws iam detach-role-policy \
+                --role-name "$role_name" \
+                --policy-arn "$policy_arn" >/dev/null 2>&1; then
+                debug_log "Detached policy from role: $role_name"
             else
-                # Detach policy from role
-                if aws iam detach-role-policy \
-                    --role-name "$role_name" \
-                    --policy-arn "$policy_arn" >/dev/null 2>&1; then
-                    debug_log "Detached policy from role: $role_name"
-                else
-                    log_warn "Failed to detach policy from role (may already be detached)"
-                fi
-            fi
-
-            # Delete the policy
-            if aws iam delete-policy --policy-arn "$policy_arn" >/dev/null 2>&1; then
-                debug_log "Deleted policy: $policy_arn"
-            else
-                log_warn "Failed to delete policy (may already be deleted): $policy_arn"
+                log_warn "Failed to detach policy from role (may already be detached)"
             fi
         fi
-    done <<< "$policy_files"
 
+        # Delete the policy
+        if aws iam delete-policy --policy-arn "$policy_arn" >/dev/null 2>&1; then
+            debug_log "Deleted policy: $policy_arn"
+        else
+            log_warn "Failed to delete policy (may already be deleted): $policy_arn"
+        fi
+    done <<< "$policy_entries"
+
+    # Remove policies from registry for this instance
+    remove_policies_from_registry "$instance_id"
+
+    # Release lock after cleanup
+    release_instance_lock "$lock_file"
     return 0
 }
 
-# Background function to manage S3 permissions
+# Manage S3 permissions with proper locking
 manage_s3_permissions() {
     local action="$1"  # "attach" or "remove"
     local instance_id="$2"
@@ -528,7 +792,6 @@ manage_s3_permissions() {
 
     case "$action" in
         "attach")
-            # Run attach operation synchronously - no need for backgrounding since we wait anyway
             if attach_s3_permissions "$instance_id" "$region" "$bucket_name"; then
                 debug_log "S3 permissions attached successfully"
                 return 0
@@ -538,15 +801,16 @@ manage_s3_permissions() {
             fi
             ;;
         "remove")
-            # Run remove operation in background for non-blocking cleanup
-            remove_s3_permissions "$instance_id" "$region" &
-            local remove_pid=$!
-            debug_log "Started S3 permissions removal in background (PID: $remove_pid)"
-            
-            # Don't wait for removal to complete - let it run in background
-            disown $remove_pid 2>/dev/null || true
-            debug_log "S3 permissions removal running in background"
-            return 0
+            # Run remove operation synchronously with proper locking
+            # Background execution removed to prevent race conditions
+            if remove_s3_permissions "$instance_id" "$region"; then
+                debug_log "S3 permissions removed successfully"
+                return 0
+            else
+                log_warn "Failed to remove S3 permissions (may already be cleaned up)"
+                # Don't return error for removal failures as they're often expected
+                return 0
+            fi
             ;;
         *)
             log_error "Invalid action for manage_s3_permissions: $action"
@@ -972,56 +1236,134 @@ emergency_cleanup_s3_permissions() {
     
     debug_log "Performing emergency cleanup of temporary S3 policies..."
     
-    # Find all temporary policy files
-    local policy_files
-    policy_files=$(find /tmp -name "ztiaws-s3-policy-*" -type f 2>/dev/null || true)
-    
-    if [[ -z "$policy_files" ]]; then
-        debug_log "No temporary policy files found for cleanup"
-        return 0
-    fi
-    
-    if [[ -z "$region" ]]; then
-        log_warn "No region provided for emergency cleanup - will attempt cleanup without region context"
-    fi
-    
-    local cleanup_count=0
-    while IFS= read -r policy_file; do
-        if [[ -f "$policy_file" ]]; then
-            local policy_arn
-            policy_arn=$(cat "$policy_file" 2>/dev/null)
+    # First try to clean up from registry if it exists
+    if [[ -f "$POLICY_REGISTRY_FILE" ]]; then
+        debug_log "Using registry for emergency cleanup"
+        local cleanup_count=0
+        
+        while IFS='|' read -r instance_id reg_region policy_arn policy_file timestamp; do
+            # Skip empty lines
+            [[ -z "$instance_id" ]] && continue
             
-            if [[ -n "$policy_arn" ]]; then
-                # Extract instance ID from filename using more robust pattern
-                local instance_id
-                if [[ $(basename "$policy_file") =~ ztiaws-s3-policy-([^-]+) ]]; then
-                    instance_id="${BASH_REMATCH[1]}"
-                    debug_log "Extracted instance ID: $instance_id from policy file"
-                    
-                    if [[ -n "$instance_id" && -n "$region" ]]; then
-                        remove_s3_permissions "$instance_id" "$region" >/dev/null 2>&1
-                        ((cleanup_count++))
-                    fi
-                else
-                    debug_log "Could not extract instance ID from filename: $(basename "$policy_file")"
-                    # Fallback to direct policy cleanup if pattern doesn't match
-                    if [[ -n "$policy_arn" ]]; then
-                        debug_log "Attempting direct policy cleanup: $policy_arn"
-                        aws iam delete-policy --policy-arn "$policy_arn" >/dev/null 2>&1 || true
-                        ((cleanup_count++))
-                    fi
+            debug_log "Emergency cleanup for policy: $policy_arn (instance: $instance_id)"
+            
+            # Clean up policy file
+            if [[ -f "$policy_file" ]]; then
+                rm -f "$policy_file"
+            fi
+            
+            # Use provided region or fall back to registry region
+            local cleanup_region="${region:-$reg_region}"
+            
+            if [[ -n "$cleanup_region" && -n "$instance_id" ]]; then
+                # Try to get role name and detach policy
+                local role_name
+                if role_name=$(get_instance_profile_role "$instance_id" "$cleanup_region" 2>/dev/null); then
+                    aws iam detach-role-policy \
+                        --role-name "$role_name" \
+                        --policy-arn "$policy_arn" >/dev/null 2>&1 || true
                 fi
             fi
             
-            rm -f "$policy_file"
+            # Delete the policy
+            if [[ -n "$policy_arn" ]]; then
+                aws iam delete-policy --policy-arn "$policy_arn" >/dev/null 2>&1 || true
+                ((cleanup_count++))
+            fi
+            
+        done < "$POLICY_REGISTRY_FILE"
+        
+        # Clear the registry after cleanup
+        : > "$POLICY_REGISTRY_FILE"
+        
+        if [ $cleanup_count -gt 0 ]; then
+            debug_log "Emergency cleanup completed for $cleanup_count policies from registry"
+        else
+            debug_log "No policies found in registry for cleanup"
         fi
-    done <<< "$policy_files"
-    
-    if [ $cleanup_count -gt 0 ]; then
-        debug_log "Emergency cleanup completed for $cleanup_count policy files"
     else
-        debug_log "No policies required cleanup"
+        debug_log "No registry file found, attempting fallback cleanup"
+        
+        # Fallback: scan our dedicated temp directory only (much more efficient than scanning all of /tmp)
+        if [[ -d "$ZTIAWS_TEMP_DIR" ]]; then
+            local policy_files
+            policy_files=$(find "$ZTIAWS_TEMP_DIR" -name "ztiaws-s3-policy-*" -type f 2>/dev/null || true)
+            
+            if [[ -n "$policy_files" ]]; then
+                local cleanup_count=0
+                while IFS= read -r policy_file; do
+                    if [[ -f "$policy_file" ]]; then
+                        local policy_arn
+                        policy_arn=$(cat "$policy_file" 2>/dev/null)
+                        
+                        if [[ -n "$policy_arn" ]]; then
+                            # Extract instance ID from filename using more robust pattern
+                            local instance_id
+                            if [[ $(basename "$policy_file") =~ ztiaws-s3-policy-(i-[a-f0-9]+) ]]; then
+                                instance_id="${BASH_REMATCH[1]}"
+                                debug_log "Extracted instance ID: $instance_id from policy file"
+                                
+                                if [[ -n "$instance_id" && -n "$region" ]]; then
+                                    # Try to get role name and detach policy
+                                    local role_name
+                                    if role_name=$(get_instance_profile_role "$instance_id" "$region" 2>/dev/null); then
+                                        aws iam detach-role-policy \
+                                            --role-name "$role_name" \
+                                            --policy-arn "$policy_arn" >/dev/null 2>&1 || true
+                                    fi
+                                fi
+                            else
+                                debug_log "Could not extract instance ID from filename: $(basename "$policy_file")"
+                            fi
+                            
+                            # Delete the policy regardless
+                            debug_log "Attempting direct policy cleanup: $policy_arn"
+                            aws iam delete-policy --policy-arn "$policy_arn" >/dev/null 2>&1 || true
+                            ((cleanup_count++))
+                        fi
+                        
+                        rm -f "$policy_file"
+                    fi
+                done <<< "$policy_files"
+                
+                if [ $cleanup_count -gt 0 ]; then
+                    debug_log "Fallback cleanup completed for $cleanup_count policy files"
+                else
+                    debug_log "No policies required cleanup in fallback mode"
+                fi
+            else
+                debug_log "No temporary policy files found in dedicated directory"
+            fi
+        fi
     fi
+    
+    # Clean up stale lock files (older than 5 minutes)
+    if [[ -d "$LOCK_DIR" ]]; then
+        debug_log "Cleaning up stale lock files..."
+        local lock_cleanup_count=0
+        
+        find "$LOCK_DIR" -name "iam-*.lock" -type d 2>/dev/null | while read -r lock_file; do
+            if [[ -d "$lock_file" ]]; then
+                local lock_age
+                if lock_age=$(stat -c %Y "$lock_file" 2>/dev/null); then
+                    local current_time=$(date +%s)
+                    local age_seconds=$((current_time - lock_age))
+                    
+                    if [ $age_seconds -gt 300 ]; then  # 5 minutes
+                        debug_log "Removing stale lock: $(basename "$lock_file") (age: ${age_seconds}s)"
+                        rmdir "$lock_file" 2>/dev/null || true
+                        ((lock_cleanup_count++))
+                    fi
+                fi
+            fi
+        done
+        
+        # Try to remove lock directory if empty
+        rmdir "$LOCK_DIR" 2>/dev/null || true
+    fi
+    
+    # Clean up stale registry entries
+    cleanup_stale_registry_entries >/dev/null 2>&1 || true
     
     return 0
 }


### PR DESCRIPTION
The system works automatically when users attempt large file transfers (≥1MB). It will:

1. Validate the EC2 instance has an IAM instance profile
2. Extract the role name from the instance profile
3. Create a temporary S3 policy with minimal permissions for the specific bucket
4. Attach the policy to the role
5. Perform the file transfer operation
6. Clean up the temporary policy in the background

This ensures that EC2 instances can access S3 for file transfers without requiring permanent broad S3 permissions, improving security while maintaining functionality.