### PR TITLE
Issues/34 add authaws flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
     - Connect to EC2 instances via AWS Systems Manager Session Manager using intuitive short region codes.
     - Execute commands remotely on a single EC2 instance (`ssm exec`).
     - Execute commands remotely on multiple EC2 instances based on AWS tags (`ssm exec-tagged`).
-- **authaws**: Streamlined AWS SSO authentication with interactive account/role selection.
+- **authaws**: Streamlined AWS SSO authentication with interactive account/role selection. Supports both traditional positional syntax and modern flag-based parameters.
 - Smart interactive listing of available instances (for `ssm <region>`) and accounts/roles (for `authaws`).
 - Automatic validation of AWS CLI and required plugins.
 - Enhanced error reporting: Clear feedback for AWS CLI issues and specific handling for scenarios like no instances matching tags during command execution.
@@ -117,6 +117,8 @@ authaws check       # Check dependencies
 authaws help        # Show help information
 ```
 
+**Available flags**: `--profile`, `--region`, `--sso-url`, `--export`, `--list-profiles`, `--debug`, `--help`, `--version`, `--check`, `--creds`
+
 Before using `authaws`, set up a `.env` file in the same directory with the following content:
 ```
 SSO_START_URL="https://your-sso-url.awsapps.com/start"
@@ -128,8 +130,14 @@ You can create a template file by running `authaws` without a valid .env file.
 
 #### Log in to AWS SSO
 ```bash
+# Traditional syntax (backward compatible)
 authaws             # Use default profile from .env
 authaws myprofile   # Use a specific profile name
+
+# Flag-based syntax (new)
+authaws --profile myprofile                    # Use specific profile
+authaws --profile prod --region us-east-1      # Override region
+authaws --profile dev --sso-url https://alt.awsapps.com/start  # Override SSO URL
 ```
 
 The tool will:
@@ -141,8 +149,14 @@ The tool will:
 
 #### View AWS Credentials
 ```bash
+# Traditional syntax
 authaws creds           # Show credentials for current profile
 authaws creds myprofile # Show credentials for a specific profile
+
+# Flag-based syntax
+authaws --creds                           # Show credentials for current profile
+authaws --creds --profile myprofile       # Show credentials for specific profile
+authaws --creds --profile myprofile --export  # Export format for shell evaluation
 ```
 
 This will display your AWS access key, secret key, and session token for the specified profile.

--- a/authaws
+++ b/authaws
@@ -216,7 +216,8 @@ show_credentials() {
   local profile_name="$1"
   
   # Check if export flag is set
-  local export_mode="$(get_auth_export)"
+  local export_mode
+  export_mode="$(get_auth_export)"
   
   if [[ "$export_mode" != "true" ]]; then
     log_info "🔐 Retrieving credentials for profile: $profile_name"
@@ -296,7 +297,8 @@ main() {
   fi
 
   if [[ "$(get_auth_creds)" == "true" ]]; then
-    local cred_profile="$(get_auth_profile)"
+    local cred_profile
+    cred_profile="$(get_auth_profile)"
     if [[ -z "$cred_profile" ]]; then
       # If no profile specified, try to use the current AWS_PROFILE or the default profile
       cred_profile="${AWS_PROFILE:-}"
@@ -349,7 +351,8 @@ main() {
   done
 
   # Set profile name from parsed parameters or use default
-  local profile_name="$(get_auth_profile)"
+  local profile_name
+  profile_name="$(get_auth_profile)"
   if [[ -z "$profile_name" ]]; then
     log_info "No profile specified. Using default: $DEFAULT_PROFILE"
     # Fix SC2162: Add -r flag to read
@@ -368,12 +371,20 @@ main() {
   log_info "Configuring AWS profile: $PROFILE_NAME"
   
   # Use parsed parameters or fall back to .env values
-  local sso_start_url="$(get_auth_sso_url)"
-  local sso_region="$(get_auth_region)"
+  local sso_start_url
+  local sso_region
+  sso_start_url="$(get_auth_sso_url)"
+  sso_region="$(get_auth_region)"
   
   # Use provided values or fall back to .env defaults
-  [[ -z "$sso_start_url" ]] && sso_start_url="$SSO_START_URL"
-  [[ -z "$sso_region" ]] && sso_region="$SSO_REGION"
+  # shellcheck disable=SC2153
+  if [[ -z "$sso_start_url" ]]; then
+    sso_start_url="${SSO_START_URL}"
+  fi
+  # shellcheck disable=SC2153
+  if [[ -z "$sso_region" ]]; then
+    sso_region="${SSO_REGION}"
+  fi
   
   # Fix SC2086: Double quote to prevent globbing and word splitting
   aws configure set "profile.${PROFILE_NAME}.sso_start_url" "$sso_start_url"

--- a/authaws
+++ b/authaws
@@ -110,7 +110,7 @@ FLAGS:
 
 EXAMPLES:
   # Power user workflow (current syntax)
-  authaws                                  # Login with default profile
+  authaws                                  # Show help (no profile specified)
   authaws dev-profile                      # Login with specific profile
   authaws check                            # Verify dependencies
   authaws creds dev-profile                # Show credentials for a profile

--- a/authaws
+++ b/authaws
@@ -24,6 +24,19 @@ else
     exit 1
 fi
 
+# Source parameter parser module
+if [ -f "${SCRIPT_DIR}/src/06_authaws_parameter_parser.sh" ]; then
+    # shellcheck source=./src/06_authaws_parameter_parser.sh
+    source "${SCRIPT_DIR}/src/06_authaws_parameter_parser.sh"
+elif [ -f "/usr/local/bin/src/06_authaws_parameter_parser.sh" ]; then
+    # shellcheck source=/dev/null
+    source "/usr/local/bin/src/06_authaws_parameter_parser.sh"
+else
+    echo "[ERROR] src/06_authaws_parameter_parser.sh not found. This script requires the parameter parser module." >&2
+    echo "Please ensure src/06_authaws_parameter_parser.sh is present in the script directory or in /usr/local/bin/src/." >&2
+    exit 1
+fi
+
 # Get the directory where the script is located
 ENV_FILE="${SCRIPT_DIR}/.env"
 
@@ -59,26 +72,50 @@ EOL
 show_help() {
   cat << 'EOL'
 AWS SSO Authentication Helper
-Usage: authaws [profile-name]
-       authaws              # Uses default profile from .env file
 
-Commands:
-  authaws help       # Show this help message
-  authaws version    # Show version information
-  authaws check      # Check system requirements
-  authaws creds      # Show decoded credentials for a profile
+USAGE:
+  authaws [profile-name]                    # Positional syntax (backward compatible)
+  authaws --profile <name>                  # Flag-based syntax (enterprise friendly)
 
-Setup:
+COMMANDS:
+  authaws help                              # Show this help message
+  authaws --help, -h                        # Show this help message
+  authaws version                           # Show version information
+  authaws --version, -v                     # Show version information
+  authaws check                             # Check system requirements
+  authaws --check                           # Check system requirements
+  authaws creds [profile]                   # Show decoded credentials for a profile
+  authaws --creds [--profile <name>]        # Show decoded credentials for a profile
+
+FLAGS:
+  --profile, -p <name>                      # Profile name to use
+  --region, -r <region>                     # Override default region
+  --sso-url <url>                          # Override SSO start URL
+  --export                                 # Export credentials to stdout
+  --list-profiles                          # List available profiles
+  --debug                                  # Enable debug mode
+
+EXAMPLES:
+  # Power user workflow (current syntax)
+  authaws                                  # Login with default profile
+  authaws dev-profile                      # Login with specific profile
+  authaws check                            # Verify dependencies
+  authaws creds dev-profile                # Show credentials for a profile
+
+  # Enterprise workflow (new syntax)
+  authaws --profile dev-profile            # Login with specific profile
+  authaws --profile prod --region us-east-1 # Override region
+  authaws --creds --profile dev-profile    # Show credentials for a profile
+  authaws --profile dev --export           # Export credentials to stdout
+
+  # Future extensibility
+  authaws --profile dev --sso-url https://alt.awsapps.com/start
+
+SETUP:
   Before first use, create a .env file in the script directory with:
   SSO_START_URL="https://your-sso-url.awsapps.com/start"
   SSO_REGION="your-region"
   DEFAULT_PROFILE="your-default-profile"
-
-Examples:
-  authaws                # Login with default profile
-  authaws dev-profile    # Login with specific profile
-  authaws check          # Verify dependencies
-  authaws creds [profile]  # Show credentials for a profile
 EOL
   exit 0
 }
@@ -88,6 +125,32 @@ VERSION="1.4.1"
 show_version() {
   echo "AWS SSO Authentication Helper version: $VERSION"
   exit 0
+}
+
+# Function to list available profiles
+list_available_profiles() {
+  log_info "📋 Available AWS profiles:"
+  
+  # Get profiles from AWS config
+  local profiles
+  profiles=$(aws configure list-profiles 2>/dev/null || echo "")
+  
+  if [[ -z "$profiles" ]]; then
+    log_warn "No AWS profiles found. You may need to run 'aws configure' first."
+    return 0
+  fi
+  
+  # Display profiles in a nice format
+  echo "$profiles" | while IFS= read -r profile; do
+    if [[ -n "$profile" ]]; then
+      echo "  • $profile"
+    fi
+  done
+  
+  log_info ""
+  log_info "To use a profile, run:"
+  log_info "  authaws <profile-name>"
+  log_info "  authaws --profile <profile-name>"
 }
 
 
@@ -152,7 +215,12 @@ is_token_valid() {
 show_credentials() {
   local profile_name="$1"
   
-  log_info "🔐 Retrieving credentials for profile: $profile_name"
+  # Check if export flag is set
+  local export_mode="$(get_auth_export)"
+  
+  if [[ "$export_mode" != "true" ]]; then
+    log_info "🔐 Retrieving credentials for profile: $profile_name"
+  fi
   
   # Check if the profile exists in AWS config
   if ! aws configure list --profile "$profile_name" &>/dev/null; then
@@ -183,59 +251,75 @@ show_credentials() {
     fi
   fi
   
-  # Display the credentials
-  echo ""
-  log_info "🔑 AWS Credentials for profile: $profile_name"
-  log_info "----------------------------------------"
-  echo "$creds_output"
-  log_info "----------------------------------------"
-  log_info "To use these credentials in your current shell, run:"
-  log_info "eval \$(aws configure export-credentials --profile $profile_name --format env)"
+  # Display the credentials based on export mode
+  if [[ "$export_mode" == "true" ]]; then
+    # Export mode: just output the credentials without additional formatting
+    echo "$creds_output"
+  else
+    # Normal mode: display with formatting
+    echo ""
+    log_info "🔑 AWS Credentials for profile: $profile_name"
+    log_info "----------------------------------------"
+    echo "$creds_output"
+    log_info "----------------------------------------"
+    log_info "To use these credentials in your current shell, run:"
+    log_info "eval \$(aws configure export-credentials --profile $profile_name --format env)"
+  fi
   
   return 0
 }
 
 # Main function
 main() {
-  # Handle special commands first
-  case "${1:-}" in
-    "help"|"-h"|"--help")
-      show_help
-      ;;
-    "version")
-      show_version
-      ;;
-    "check")
-      if check_requirements; then
-        log_info "System requirements check passed"
-      else
-        log_error "System requirements not met"
-        exit 1
-      fi
-      exit 0
-      ;;
-    "creds")
-      if [[ $# -lt 2 ]]; then
-        # If no profile specified, try to use the current AWS_PROFILE or the default profile
-        local cred_profile="${AWS_PROFILE:-}"
-        if [[ -z "$cred_profile" ]]; then
-          if [[ -f "${ENV_FILE}" ]]; then
-            # shellcheck source=/dev/null
-            source "${ENV_FILE}"
-            cred_profile="$DEFAULT_PROFILE"
-          else
-            log_error "No profile specified and no default profile found"
-            log_info "Usage: $0 creds [profile-name]"
-            exit 1
-          fi
+  # Parse parameters using the new parameter parser
+  if ! parse_authaws_parameters "$@"; then
+    exit 1
+  fi
+
+  # Handle commands based on parsed parameters
+  if [[ "$(get_auth_help)" == "true" ]]; then
+    show_help
+  fi
+
+  if [[ "$(get_auth_version)" == "true" ]]; then
+    show_version
+  fi
+
+  if [[ "$(get_auth_check)" == "true" ]]; then
+    if check_requirements; then
+      log_info "System requirements check passed"
+    else
+      log_error "System requirements not met"
+      exit 1
+    fi
+    exit 0
+  fi
+
+  if [[ "$(get_auth_creds)" == "true" ]]; then
+    local cred_profile="$(get_auth_profile)"
+    if [[ -z "$cred_profile" ]]; then
+      # If no profile specified, try to use the current AWS_PROFILE or the default profile
+      cred_profile="${AWS_PROFILE:-}"
+      if [[ -z "$cred_profile" ]]; then
+        if [[ -f "${ENV_FILE}" ]]; then
+          # shellcheck source=/dev/null
+          source "${ENV_FILE}"
+          cred_profile="$DEFAULT_PROFILE"
+        else
+          log_error "No profile specified and no default profile found"
+          log_info "Usage: $0 creds [profile-name] or $0 --creds --profile <name>"
+          exit 1
         fi
-        show_credentials "$cred_profile"
-      else
-        show_credentials "$2"
       fi
-      exit $?
-      ;;
-  esac
+    fi
+    show_credentials "$cred_profile"
+    exit $?
+  fi
+
+  if [[ "$(get_auth_list_profiles)" == "true" ]]; then
+    list_available_profiles
+    exit 0
+  fi
 
   # Check for .env file and load it
   if [[ -f "${ENV_FILE}" ]]; then
@@ -264,27 +348,37 @@ main() {
     fi
   done
 
-  # Set profile name from argument or use default
-  if [[ $# -eq 0 ]]; then
+  # Set profile name from parsed parameters or use default
+  local profile_name="$(get_auth_profile)"
+  if [[ -z "$profile_name" ]]; then
     log_info "No profile specified. Using default: $DEFAULT_PROFILE"
     # Fix SC2162: Add -r flag to read
     read -r -p "Proceed with default profile? (y/n): " proceed
     if [[ $proceed =~ ^[Yy]$ ]]; then
       PROFILE_NAME="$DEFAULT_PROFILE"
     else
-      log_info "Please run: $0 <profile-name>"
+      log_info "Please run: $0 <profile-name> or $0 --profile <name>"
       exit 1
     fi
   else
-    PROFILE_NAME="$1"
+    PROFILE_NAME="$profile_name"
   fi
 
   # Configure the profile
   log_info "Configuring AWS profile: $PROFILE_NAME"
+  
+  # Use parsed parameters or fall back to .env values
+  local sso_start_url="$(get_auth_sso_url)"
+  local sso_region="$(get_auth_region)"
+  
+  # Use provided values or fall back to .env defaults
+  [[ -z "$sso_start_url" ]] && sso_start_url="$SSO_START_URL"
+  [[ -z "$sso_region" ]] && sso_region="$SSO_REGION"
+  
   # Fix SC2086: Double quote to prevent globbing and word splitting
-  aws configure set "profile.${PROFILE_NAME}.sso_start_url" "$SSO_START_URL"
-  aws configure set "profile.${PROFILE_NAME}.sso_region" "$SSO_REGION"
-  aws configure set "profile.${PROFILE_NAME}.region" "$SSO_REGION"
+  aws configure set "profile.${PROFILE_NAME}.sso_start_url" "$sso_start_url"
+  aws configure set "profile.${PROFILE_NAME}.sso_region" "$sso_region"
+  aws configure set "profile.${PROFILE_NAME}.region" "$sso_region"
   aws configure set "profile.${PROFILE_NAME}.output" "json"
 
   # Check cached credentials

--- a/authaws
+++ b/authaws
@@ -24,6 +24,19 @@ else
     exit 1
 fi
 
+# Source regions module (required for region validation)
+if [ -f "${SCRIPT_DIR}/src/01_regions.sh" ]; then
+    # shellcheck source=./src/01_regions.sh
+    source "${SCRIPT_DIR}/src/01_regions.sh"
+elif [ -f "/usr/local/bin/src/01_regions.sh" ]; then
+    # shellcheck source=/dev/null
+    source "/usr/local/bin/src/01_regions.sh"
+else
+    echo "[ERROR] src/01_regions.sh not found. This script requires the regions module for region validation." >&2
+    echo "Please ensure src/01_regions.sh is present in the script directory or in /usr/local/bin/src/." >&2
+    exit 1
+fi
+
 # Source parameter parser module
 if [ -f "${SCRIPT_DIR}/src/06_authaws_parameter_parser.sh" ]; then
     # shellcheck source=./src/06_authaws_parameter_parser.sh

--- a/src/06_authaws_parameter_parser.sh
+++ b/src/06_authaws_parameter_parser.sh
@@ -93,9 +93,9 @@ parse_positional_parameters() {
     local args=("$@")
     
     if [[ ${#args[@]} -eq 0 ]]; then
-        # No arguments - use default profile
-        AUTH_PROFILE=""
-        AUTH_COMMAND=""
+        # No arguments - show help instead of trying to use default profile
+        AUTH_HELP="true"
+        AUTH_COMMAND="help"
         return 0
     fi
     
@@ -318,10 +318,13 @@ validate_parameter_combinations() {
     # Validate region if specified
     if [[ -n "$AUTH_REGION" ]]; then
         # Always use validate_region_code from regions.sh
-        if ! validate_region_code "$AUTH_REGION" region_var; then
+        local validated_region
+        if ! validate_region_code "$AUTH_REGION" validated_region; then
             log_error "Error: Invalid region '$AUTH_REGION'"
             return 1
         fi
+        # Optional: Update AUTH_REGION with the validated full region name
+        AUTH_REGION="$validated_region"
     fi
     
     # Validate SSO URL if specified

--- a/src/06_authaws_parameter_parser.sh
+++ b/src/06_authaws_parameter_parser.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+
+# AuthAWS Parameter Parser Module
+# Version: 1.0.0
+# Repository: https://github.com/ZSoftly/ztiaws
+# 
+# This module provides unified parameter parsing for authaws, supporting both
+# positional and flag-based syntax while maintaining full backward compatibility.
+# 
+# Compatibility: bash 3.2+ (macOS compatible)
+# Usage: source this file in authaws script, then call parse_authaws_parameters "$@"
+
+# Global variables to store parsed parameters
+# Using regular variable assignment for bash 3.2 compatibility
+AUTH_PROFILE=""
+AUTH_COMMAND=""
+AUTH_REGION=""
+AUTH_SSO_URL=""
+AUTH_EXPORT="false"
+AUTH_LIST_PROFILES="false"
+AUTH_CHECK="false"
+AUTH_CREDS="false"
+AUTH_HELP="false"
+AUTH_VERSION="false"
+AUTH_DEBUG="false"
+
+# Function to detect if arguments contain flags
+has_flags() {
+    local args=("$@")
+    for arg in "${args[@]}"; do
+        if [[ "$arg" =~ ^- ]]; then
+            return 0  # Found a flag
+        fi
+    done
+    return 1  # No flags found
+}
+
+# Function to show parameter parser help
+show_parameter_help() {
+    cat << 'EOL'
+AuthAWS Parameter Parser Help
+
+This module supports both positional and flag-based parameter syntax:
+
+POSITIONAL SYNTAX (current - backward compatible):
+  authaws [profile-name]           # Use specific profile
+  authaws check                    # Check system requirements
+  authaws creds [profile]          # Show credentials
+  authaws help                     # Show help
+  authaws version                  # Show version
+
+FLAG-BASED SYNTAX (new - enterprise friendly):
+  authaws --profile <name>         # Use specific profile
+  authaws --check                  # Check system requirements
+  authaws --creds [--profile <name>] # Show credentials
+  authaws --help                   # Show help
+  authaws --version                # Show version
+
+MIXED SYNTAX (also supported):
+  authaws dev-profile --region us-west-2
+  authaws --profile dev-profile --export
+
+AVAILABLE FLAGS:
+  --profile, -p <name>             # Profile name to use
+  --region, -r <region>            # Override default region
+  --sso-url <url>                  # Override SSO start URL
+  --export                         # Export credentials to stdout
+  --list-profiles                  # List available profiles
+  --check                          # Check system requirements
+  --creds                          # Show credentials
+  --help, -h                       # Show help
+  --version, -v                    # Show version
+  --debug                          # Enable debug mode
+
+EXAMPLES:
+  # Power user workflow (current syntax)
+  authaws dev-profile
+  authaws creds
+
+  # Enterprise workflow (new syntax)
+  authaws --profile dev-profile
+  authaws --profile prod --region us-east-1
+  authaws --creds --profile dev-profile
+
+  # Future extensibility
+  authaws --profile dev --sso-url https://alt.awsapps.com/start
+  authaws --profile dev --export
+EOL
+}
+
+# Function to parse positional parameters (current behavior)
+parse_positional_parameters() {
+    local args=("$@")
+    
+    if [[ ${#args[@]} -eq 0 ]]; then
+        # No arguments - use default profile
+        AUTH_PROFILE=""
+        AUTH_COMMAND=""
+        return 0
+    fi
+    
+    local first_arg="${args[0]}"
+    
+    # Check for commands first
+    case "$first_arg" in
+        "check")
+            AUTH_COMMAND="check"
+            AUTH_CHECK="true"
+            return 0
+            ;;
+        "creds")
+            AUTH_COMMAND="creds"
+            AUTH_CREDS="true"
+            # Check if second argument is a profile
+            if [[ ${#args[@]} -gt 1 ]]; then
+                AUTH_PROFILE="${args[1]}"
+            fi
+            return 0
+            ;;
+        "help")
+            AUTH_COMMAND="help"
+            AUTH_HELP="true"
+            return 0
+            ;;
+        "version")
+            AUTH_COMMAND="version"
+            AUTH_VERSION="true"
+            return 0
+            ;;
+        *)
+            # Assume it's a profile name
+            AUTH_PROFILE="$first_arg"
+            AUTH_COMMAND="login"
+            return 0
+            ;;
+    esac
+}
+
+# Function to parse flag-based parameters
+parse_flag_parameters() {
+    local args=("$@")
+    local i=0
+    
+    while [[ $i -lt ${#args[@]} ]]; do
+        local arg="${args[$i]}"
+        
+        case "$arg" in
+            # Profile flags
+            "--profile"|"-p")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    AUTH_PROFILE="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --profile requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # Region flag
+            "--region"|"-r")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    AUTH_REGION="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --region requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # SSO URL flag
+            "--sso-url")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    AUTH_SSO_URL="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --sso-url requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # Boolean flags
+            "--export")
+                AUTH_EXPORT="true"
+                i=$((i+1))
+                ;;
+            
+            "--list-profiles")
+                AUTH_LIST_PROFILES="true"
+                AUTH_COMMAND="list-profiles"
+                i=$((i+1))
+                ;;
+            
+            "--check")
+                AUTH_CHECK="true"
+                AUTH_COMMAND="check"
+                i=$((i+1))
+                ;;
+            
+            "--creds")
+                AUTH_CREDS="true"
+                AUTH_COMMAND="creds"
+                i=$((i+1))
+                ;;
+            
+            "--help"|"-h")
+                AUTH_HELP="true"
+                AUTH_COMMAND="help"
+                i=$((i+1))
+                ;;
+            
+            "--version"|"-v")
+                AUTH_VERSION="true"
+                AUTH_COMMAND="version"
+                i=$((i+1))
+                ;;
+            
+            "--debug")
+                AUTH_DEBUG="true"
+                i=$((i+1))
+                ;;
+            
+            # Unknown flag
+            -*)
+                log_error "Error: Unknown flag '$arg'"
+                log_error "Use 'authaws --help' for usage information"
+                return 1
+                ;;
+            
+            # Positional argument (fallback for mixed syntax)
+            *)
+                # If we haven't set a profile yet, treat this as a profile name
+                if [[ -z "$AUTH_PROFILE" && -z "$AUTH_COMMAND" ]]; then
+                    AUTH_PROFILE="$arg"
+                    AUTH_COMMAND="login"
+                else
+                    log_error "Error: Unexpected positional argument '$arg'"
+                    log_error "Use 'authaws --help' for usage information"
+                    return 1
+                fi
+                i=$((i+1))
+                ;;
+        esac
+    done
+    
+    return 0
+}
+
+# Main parameter parsing function
+parse_authaws_parameters() {
+    local args=("$@")
+    
+    # Reset global variables
+    AUTH_PROFILE=""
+    AUTH_COMMAND=""
+    AUTH_REGION=""
+    AUTH_SSO_URL=""
+    AUTH_EXPORT="false"
+    AUTH_LIST_PROFILES="false"
+    AUTH_CHECK="false"
+    AUTH_CREDS="false"
+    AUTH_HELP="false"
+    AUTH_VERSION="false"
+    AUTH_DEBUG="false"
+    
+    # Check if arguments contain flags
+    if has_flags "${args[@]}"; then
+        # Parse as flag-based parameters
+        if ! parse_flag_parameters "${args[@]}"; then
+            return 1
+        fi
+    else
+        # Parse as positional parameters (backward compatibility)
+        if ! parse_positional_parameters "${args[@]}"; then
+            return 1
+        fi
+    fi
+    
+    # Validate parameter combinations
+    if ! validate_parameter_combinations; then
+        return 1
+    fi
+    
+    # Debug output if debug mode is enabled
+    if [[ "$AUTH_DEBUG" == "true" ]]; then
+        debug_log "Parsed parameters:"
+        debug_log "  Profile: '$AUTH_PROFILE'"
+        debug_log "  Command: '$AUTH_COMMAND'"
+        debug_log "  Region: '$AUTH_REGION'"
+        debug_log "  SSO URL: '$AUTH_SSO_URL'"
+        debug_log "  Export: '$AUTH_EXPORT'"
+        debug_log "  List Profiles: '$AUTH_LIST_PROFILES'"
+        debug_log "  Check: '$AUTH_CHECK'"
+        debug_log "  Creds: '$AUTH_CREDS'"
+        debug_log "  Help: '$AUTH_HELP'"
+        debug_log "  Version: '$AUTH_VERSION'"
+        debug_log "  Debug: '$AUTH_DEBUG'"
+    fi
+    
+    return 0
+}
+
+# Function to validate parameter combinations
+validate_parameter_combinations() {
+    # Check for mutually exclusive commands
+    local command_count=0
+    [[ "$AUTH_CHECK" == "true" ]] && command_count=$((command_count + 1))
+    [[ "$AUTH_CREDS" == "true" ]] && command_count=$((command_count + 1))
+    [[ "$AUTH_HELP" == "true" ]] && command_count=$((command_count + 1))
+    [[ "$AUTH_VERSION" == "true" ]] && command_count=$((command_count + 1))
+    [[ "$AUTH_LIST_PROFILES" == "true" ]] && command_count=$((command_count + 1))
+    
+    if [[ $command_count -gt 1 ]]; then
+        log_error "Error: Multiple commands specified. Only one command allowed."
+        log_error "Commands: check, creds, help, version, list-profiles"
+        return 1
+    fi
+    
+    # Validate region if specified
+    if [[ -n "$AUTH_REGION" ]]; then
+        # Check if validate_region_code function exists (from regions.sh)
+        if type validate_region_code >/dev/null 2>&1; then
+            if ! validate_region_code "$AUTH_REGION" region_var; then
+                log_error "Error: Invalid region '$AUTH_REGION'"
+                return 1
+            fi
+        else
+            # Fallback validation for common AWS regions
+            if ! validate_aws_region "$AUTH_REGION"; then
+                log_error "Error: Invalid region '$AUTH_REGION'"
+                return 1
+            fi
+        fi
+    fi
+    
+    # Validate SSO URL if specified
+    if [[ -n "$AUTH_SSO_URL" ]]; then
+        if ! validate_sso_url "$AUTH_SSO_URL"; then
+            log_error "Error: Invalid SSO URL '$AUTH_SSO_URL'"
+            return 1
+        fi
+    fi
+    
+    return 0
+}
+
+# Function to validate SSO URL format
+validate_sso_url() {
+    local url="$1"
+    
+    # Basic URL validation for AWS SSO URLs
+    if [[ "$url" =~ ^https://[a-zA-Z0-9.-]+\.awsapps\.com/start$ ]]; then
+        return 0
+    fi
+    
+    return 1
+}
+
+# Fallback function to validate AWS regions (when regions.sh is not available)
+validate_aws_region() {
+    local region="$1"
+    
+    # List of common AWS regions for validation
+    local valid_regions=(
+        "us-east-1" "us-east-2" "us-west-1" "us-west-2"
+        "ca-central-1" "ca-west-1"
+        "eu-west-1" "eu-west-2" "eu-west-3" "eu-central-1"
+        "ap-south-1" "ap-southeast-1" "ap-southeast-2"
+        "ap-northeast-1" "ap-northeast-2" "ap-northeast-3"
+        "sa-east-1"
+    )
+    
+    for valid_region in "${valid_regions[@]}"; do
+        if [[ "$region" == "$valid_region" ]]; then
+            return 0
+        fi
+    done
+    
+    return 1
+}
+
+# Function to get parsed parameters (for use in main script)
+get_auth_profile() {
+    echo "$AUTH_PROFILE"
+}
+
+get_auth_command() {
+    echo "$AUTH_COMMAND"
+}
+
+get_auth_region() {
+    echo "$AUTH_REGION"
+}
+
+get_auth_sso_url() {
+    echo "$AUTH_SSO_URL"
+}
+
+get_auth_export() {
+    echo "$AUTH_EXPORT"
+}
+
+get_auth_list_profiles() {
+    echo "$AUTH_LIST_PROFILES"
+}
+
+get_auth_check() {
+    echo "$AUTH_CHECK"
+}
+
+get_auth_creds() {
+    echo "$AUTH_CREDS"
+}
+
+get_auth_help() {
+    echo "$AUTH_HELP"
+}
+
+get_auth_version() {
+    echo "$AUTH_VERSION"
+}
+
+get_auth_debug() {
+    echo "$AUTH_DEBUG"
+}
+
+# Function to check if a specific flag is set
+is_flag_set() {
+    local flag="$1"
+    case "$flag" in
+        "export") [[ "$AUTH_EXPORT" == "true" ]] && return 0 ;;
+        "list-profiles") [[ "$AUTH_LIST_PROFILES" == "true" ]] && return 0 ;;
+        "check") [[ "$AUTH_CHECK" == "true" ]] && return 0 ;;
+        "creds") [[ "$AUTH_CREDS" == "true" ]] && return 0 ;;
+        "help") [[ "$AUTH_HELP" == "true" ]] && return 0 ;;
+        "version") [[ "$AUTH_VERSION" == "true" ]] && return 0 ;;
+        "debug") [[ "$AUTH_DEBUG" == "true" ]] && return 0 ;;
+        *) return 1 ;;
+    esac
+    return 1
+} 

--- a/src/06_authaws_parameter_parser.sh
+++ b/src/06_authaws_parameter_parser.sh
@@ -317,18 +317,10 @@ validate_parameter_combinations() {
     
     # Validate region if specified
     if [[ -n "$AUTH_REGION" ]]; then
-        # Check if validate_region_code function exists (from regions.sh)
-        if type validate_region_code >/dev/null 2>&1; then
-            if ! validate_region_code "$AUTH_REGION" region_var; then
-                log_error "Error: Invalid region '$AUTH_REGION'"
-                return 1
-            fi
-        else
-            # Fallback validation for common AWS regions
-            if ! validate_aws_region "$AUTH_REGION"; then
-                log_error "Error: Invalid region '$AUTH_REGION'"
-                return 1
-            fi
+        # Always use validate_region_code from regions.sh
+        if ! validate_region_code "$AUTH_REGION" region_var; then
+            log_error "Error: Invalid region '$AUTH_REGION'"
+            return 1
         fi
     fi
     
@@ -347,36 +339,15 @@ validate_parameter_combinations() {
 validate_sso_url() {
     local url="$1"
     
-    # Basic URL validation for AWS SSO URLs
-    if [[ "$url" =~ ^https://[a-zA-Z0-9.-]+\.awsapps\.com/start$ ]]; then
+    # Basic URL validation for AWS SSO URLs - supports custom domains and awsapps.com
+    if [[ "$url" =~ ^https://[a-zA-Z0-9.-]+/start$ ]]; then
         return 0
     fi
     
     return 1
 }
 
-# Fallback function to validate AWS regions (when regions.sh is not available)
-validate_aws_region() {
-    local region="$1"
-    
-    # List of common AWS regions for validation
-    local valid_regions=(
-        "us-east-1" "us-east-2" "us-west-1" "us-west-2"
-        "ca-central-1" "ca-west-1"
-        "eu-west-1" "eu-west-2" "eu-west-3" "eu-central-1"
-        "ap-south-1" "ap-southeast-1" "ap-southeast-2"
-        "ap-northeast-1" "ap-northeast-2" "ap-northeast-3"
-        "sa-east-1"
-    )
-    
-    for valid_region in "${valid_regions[@]}"; do
-        if [[ "$region" == "$valid_region" ]]; then
-            return 0
-        fi
-    done
-    
-    return 1
-}
+
 
 # Function to get parsed parameters (for use in main script)
 get_auth_profile() {

--- a/tests/QA_AUTHAWS_TESTS.md
+++ b/tests/QA_AUTHAWS_TESTS.md
@@ -21,8 +21,10 @@ This document outlines the comprehensive test suite for the new flag-based param
 ### Test Data Setup
 ```bash
 # Create test .env file
+# ⚠️  WARNING: Replace with your actual SSO configuration values
+# Do not commit real credentials to version control
 cat > .env << 'EOL'
-SSO_START_URL="https://d-xxxxxxxxxx.awsapps.com/start"
+SSO_START_URL="https://your-organization.awsapps.com/start"
 SSO_REGION="us-east-1"
 DEFAULT_PROFILE="test-default-profile"
 EOL

--- a/tests/QA_AUTHAWS_TESTS.md
+++ b/tests/QA_AUTHAWS_TESTS.md
@@ -1,93 +1,428 @@
-# QA AuthAWS Test Scenarios
+# AuthAWS Flag-Based Parameters QA Test Suite
 
-**Prerequisites:** AWS CLI installed, fzf installed, jq installed, valid AWS SSO setup.
+## Overview
 
-**Setup:** Navigate to your local ztiaws directory, switch to the feature branch, use `./authaws` for all commands below.
+This document outlines the comprehensive test suite for the new flag-based parameter support in the `authaws` tool. The feature adds support for both positional and flag-based syntax while maintaining full backward compatibility.
 
-Replace `your-profile-name` with actual profile names from your environment.
+**Feature**: Support both positional and flag-based parameters for improved UX and enterprise adoption  
+**Module**: `src/06_authaws_parameter_parser.sh`  
+**Version**: 1.0.0  
+**Status**: Ready for Testing
 
-**Testing different profiles:** Use different profile names. **Testing different accounts:** Select different accounts/roles during interactive setup.
+## Test Environment Requirements
 
-## Basic Commands
+### Prerequisites
+- AWS CLI v2.x installed and configured
+- `jq` and `fzf` dependencies installed
+- Valid AWS SSO configuration in `.env` file
+- Test AWS profiles available
+- Access to AWS SSO portal
+
+### Test Data Setup
 ```bash
-./authaws help                    # Shows help
-./authaws version                 # Shows version
-./authaws check                   # Verifies requirements
+# Create test .env file
+cat > .env << 'EOL'
+SSO_START_URL="https://d-xxxxxxxxxx.awsapps.com/start"
+SSO_REGION="us-east-1"
+DEFAULT_PROFILE="test-default-profile"
+EOL
+
+# Create test profiles
+aws configure set profile.test-profile-1.sso_start_url "https://d-xxxxxxxxxx.awsapps.com/start"
+aws configure set profile.test-profile-1.sso_region "us-east-1"
+aws configure set profile.test-profile-2.sso_start_url "https://d-xxxxxxxxxx.awsapps.com/start"
+aws configure set profile.test-profile-2.sso_region "us-west-2"
 ```
 
-## Profile Authentication
-```bash
-# Default profile (from .env file)
-./authaws                         # Uses default profile from .env
+## Test Categories
 
-# Specific profile
-./authaws dev-profile             # Authenticates with specific profile
-./authaws prod-profile            # Authenticates with different profile
-./authaws my-test-profile         # Creates new profile if needed
+### 1. Backward Compatibility Tests
+
+#### Test 1.1: Positional Parameter Support
+**Objective**: Verify existing positional syntax continues to work
+
+**Test Cases**:
+```bash
+# Test 1.1.1: No arguments (default profile)
+authaws
+Expected: Uses default profile from .env
+
+# Test 1.1.2: Profile name as first argument
+authaws test-profile-1
+Expected: Uses test-profile-1
+
+# Test 1.1.3: Check command
+authaws check
+Expected: Runs system requirements check
+
+# Test 1.1.4: Creds command with profile
+authaws creds test-profile-1
+Expected: Shows credentials for test-profile-1
+
+# Test 1.1.5: Creds command without profile
+authaws creds
+Expected: Uses current AWS_PROFILE or default
 ```
 
-## Credential Management
+**Pass Criteria**: All existing positional commands work exactly as before
+
+#### Test 1.2: Existing Functionality Preservation
+**Objective**: Ensure all existing features work with new parser
+
+**Test Cases**:
 ```bash
-# Show credentials for profiles
-./authaws creds                   # Shows creds for current/default profile
-./authaws creds dev-profile       # Shows creds for specific profile
-./authaws creds nonexistent       # Profile not found error
+# Test 1.2.1: Help command
+authaws help
+Expected: Shows help with both syntaxes
+
+# Test 1.2.2: Version command
+authaws version
+Expected: Shows version information
+
+# Test 1.2.3: Check command
+authaws check
+Expected: Validates system requirements
 ```
 
-## Interactive Flows
-```bash
-# These require interactive selection via fzf
-./authaws new-profile             # Should show account selection
-# Select account -> Select role -> Profile configured
+### 2. Flag-Based Parameter Tests
 
-./authaws                         # With expired session
-# Should prompt for re-authentication
+#### Test 2.1: Basic Flag Support
+**Objective**: Verify new flag-based syntax works correctly
+
+**Test Cases**:
+```bash
+# Test 2.1.1: Profile flag
+authaws --profile test-profile-1
+Expected: Uses test-profile-1
+
+# Test 2.1.2: Short profile flag
+authaws -p test-profile-1
+Expected: Uses test-profile-1
+
+# Test 2.1.3: Help flag
+authaws --help
+Expected: Shows help
+
+# Test 2.1.4: Short help flag
+authaws -h
+Expected: Shows help
+
+# Test 2.1.5: Version flag
+authaws --version
+Expected: Shows version
+
+# Test 2.1.6: Short version flag
+authaws -v
+Expected: Shows version
 ```
 
-## Configuration Setup
+#### Test 2.2: Command Flags
+**Objective**: Test command-specific flags
+
+**Test Cases**:
 ```bash
-# First time setup (when no .env exists)
-./authaws                         # Should offer to create .env file
-# Answer 'y' -> Creates sample .env -> Shows edit instructions
+# Test 2.2.1: Check flag
+authaws --check
+Expected: Runs system requirements check
+
+# Test 2.2.2: Creds flag
+authaws --creds
+Expected: Shows credentials for current/default profile
+
+# Test 2.2.3: Creds with profile flag
+authaws --creds --profile test-profile-1
+Expected: Shows credentials for test-profile-1
+
+# Test 2.2.4: List profiles flag
+authaws --list-profiles
+Expected: Lists available AWS profiles
 ```
 
-## Error Cases
+#### Test 2.3: Advanced Flags
+**Objective**: Test new advanced functionality
+
+**Test Cases**:
 ```bash
-./authaws invalid-command         # Shows help
-./authaws creds                   # Without valid session - should show instructions
+# Test 2.3.1: Region override
+authaws --profile test-profile-1 --region us-west-2
+Expected: Uses us-west-2 region instead of default
+
+# Test 2.3.2: SSO URL override
+authaws --profile test-profile-1 --sso-url https://alt.awsapps.com/start
+Expected: Uses custom SSO URL
+
+# Test 2.3.3: Export flag
+authaws --creds --profile test-profile-1 --export
+Expected: Outputs credentials in export format only
+
+# Test 2.3.4: Debug flag
+authaws --profile test-profile-1 --debug
+Expected: Shows debug information during execution
 ```
 
-## Environment Testing
-```bash
-# Test with missing dependencies (temporarily rename)
-# mv $(which fzf) $(which fzf).bak
-# ./authaws check                 # Should show missing fzf error
-# mv $(which fzf).bak $(which fzf)
+### 3. Mixed Syntax Tests
 
-# Test with no .env file
-# mv .env .env.bak
-# ./authaws                       # Should offer to create .env
-# mv .env.bak .env
+#### Test 3.1: Positional + Flag Combinations
+**Objective**: Test mixed syntax scenarios
+
+**Test Cases**:
+```bash
+# Test 3.1.1: Positional profile + flag
+authaws test-profile-1 --region us-west-2
+Expected: Uses test-profile-1 with us-west-2 region
+
+# Test 3.1.2: Positional profile + multiple flags
+authaws test-profile-1 --region us-west-2 --export
+Expected: Uses test-profile-1 with region override and export mode
+
+# Test 3.1.3: Flag profile + positional (should fail)
+authaws --profile test-profile-1 test-profile-2
+Expected: Error - unexpected positional argument
 ```
 
-## QA Checklist
-- [ ] Basic commands work
-- [ ] Authentication flows work
-- [ ] Credential display works
-- [ ] Interactive account/role selection works
-- [ ] Profile creation works
-- [ ] Configuration setup works
-- [ ] Error handling is clear
-- [ ] Dependencies are checked
-- [ ] No regressions
+### 4. Error Handling Tests
 
-## New Features (Developers add here)
-When adding new features, developers must:
-1. Add test commands below showing the new functionality
-2. Test that existing core features (auth, creds, profiles) still work with the new feature
-3. Run full end-to-end testing to ensure no regressions
+#### Test 4.1: Invalid Flags
+**Objective**: Test error handling for invalid parameters
 
+**Test Cases**:
 ```bash
-# Add new test commands when implementing features
-# Example: ./authaws new-command profile-name
+# Test 4.1.1: Unknown flag
+authaws --unknown-flag
+Expected: Error message about unknown flag
+
+# Test 4.1.2: Missing flag value
+authaws --profile
+Expected: Error message about missing value
+
+# Test 4.1.3: Invalid region
+authaws --profile test-profile-1 --region invalid-region
+Expected: Error message about invalid region
+
+# Test 4.1.4: Invalid SSO URL
+authaws --profile test-profile-1 --sso-url invalid-url
+Expected: Error message about invalid SSO URL
 ```
+
+#### Test 4.2: Conflicting Commands
+**Objective**: Test validation of mutually exclusive commands
+
+**Test Cases**:
+```bash
+# Test 4.2.1: Multiple commands
+authaws --check --creds
+Expected: Error message about multiple commands
+
+# Test 4.2.2: Command + positional
+authaws check test-profile-1
+Expected: Error message about unexpected arguments
+```
+
+### 5. Edge Case Tests
+
+#### Test 5.1: Boundary Conditions
+**Objective**: Test edge cases and boundary conditions
+
+**Test Cases**:
+```bash
+# Test 5.1.1: Empty profile name
+authaws --profile ""
+Expected: Error or uses default profile
+
+# Test 5.1.2: Very long profile name
+authaws --profile "$(printf 'a%.0s' {1..1000})"
+Expected: Handles long profile names gracefully
+
+# Test 5.1.3: Special characters in profile name
+authaws --profile "test-profile-with-special-chars_123"
+Expected: Handles special characters correctly
+
+# Test 5.1.4: Unicode characters
+authaws --profile "test-プロファイル"
+Expected: Handles Unicode characters correctly
+```
+
+#### Test 5.2: Environment Variables
+**Objective**: Test interaction with environment variables
+
+**Test Cases**:
+```bash
+# Test 5.2.1: AWS_PROFILE environment variable
+export AWS_PROFILE=env-profile
+authaws --creds
+Expected: Uses env-profile if no profile specified
+
+# Test 5.2.2: AWS_PROFILE override
+export AWS_PROFILE=env-profile
+authaws --profile flag-profile --creds
+Expected: Uses flag-profile, ignores AWS_PROFILE
+```
+
+### 6. Integration Tests
+
+#### Test 6.1: Full Authentication Flow
+**Objective**: Test complete authentication workflow with new syntax
+
+**Test Cases**:
+```bash
+# Test 6.1.1: Full login with flags
+authaws --profile test-profile-1 --region us-west-2
+Expected: Complete SSO authentication flow
+
+# Test 6.1.2: Full login with mixed syntax
+authaws test-profile-1 --region us-west-2
+Expected: Complete SSO authentication flow
+
+# Test 6.1.3: Credential export workflow
+authaws --profile test-profile-1 --export
+Expected: Authenticates and exports credentials
+```
+
+#### Test 6.2: Profile Management
+**Objective**: Test profile listing and management
+
+**Test Cases**:
+```bash
+# Test 6.2.1: List profiles
+authaws --list-profiles
+Expected: Shows all configured AWS profiles
+
+# Test 6.2.2: Profile creation with flags
+authaws --profile new-profile --region us-east-1
+Expected: Creates new profile with specified settings
+```
+
+## Performance Tests
+
+### Test 7.1: Parser Performance
+**Objective**: Ensure parameter parsing doesn't impact performance
+
+**Test Cases**:
+```bash
+# Test 7.1.1: Parse time measurement
+time authaws --help
+Expected: Parsing completes in <100ms
+
+# Test 7.1.2: Large argument list
+authaws --profile test --region us-east-1 --sso-url https://test.awsapps.com/start --export --debug
+Expected: Handles multiple flags efficiently
+```
+
+## Regression Tests
+
+### Test 8.1: Existing Scripts
+**Objective**: Ensure existing automation scripts continue to work
+
+**Test Cases**:
+```bash
+# Test 8.1.1: CI/CD script compatibility
+./ci-script.sh  # Uses authaws with positional parameters
+Expected: Script runs without modification
+
+# Test 8.1.2: Existing aliases
+alias auth='authaws dev-profile'
+auth
+Expected: Alias works unchanged
+```
+
+## Test Execution Checklist
+
+### Pre-Test Setup
+- [ ] AWS CLI configured with test credentials
+- [ ] Test .env file created with valid SSO configuration
+- [ ] Test profiles created in AWS config
+- [ ] Dependencies (jq, fzf) installed
+- [ ] Test environment isolated from production
+
+### Test Execution
+- [ ] Run all backward compatibility tests
+- [ ] Run all flag-based parameter tests
+- [ ] Run all mixed syntax tests
+- [ ] Run all error handling tests
+- [ ] Run all edge case tests
+- [ ] Run all integration tests
+- [ ] Run performance tests
+- [ ] Run regression tests
+
+### Post-Test Validation
+- [ ] All tests pass
+- [ ] No performance degradation
+- [ ] Error messages are clear and helpful
+- [ ] Help documentation is accurate
+- [ ] Backward compatibility maintained
+
+## Expected Results
+
+### Success Criteria
+1. **100% Backward Compatibility**: All existing commands work unchanged
+2. **Flag Support**: All new flag-based syntax works correctly
+3. **Mixed Syntax**: Positional + flag combinations work as expected
+4. **Error Handling**: Clear, helpful error messages for invalid inputs
+5. **Performance**: No measurable performance impact
+6. **Documentation**: Help text accurately reflects both syntaxes
+
+### Failure Criteria
+1. Any existing command fails or behaves differently
+2. Flag-based syntax doesn't work as documented
+3. Error messages are unclear or unhelpful
+4. Performance degradation >10%
+5. Help documentation is inaccurate
+
+## Test Data Cleanup
+
+After testing, clean up test data:
+```bash
+# Remove test profiles
+aws configure set profile.test-profile-1.sso_start_url ""
+aws configure set profile.test-profile-2.sso_start_url ""
+
+# Remove test .env file
+rm -f .env
+
+# Clear any test credentials
+aws sso logout --profile test-profile-1
+aws sso logout --profile test-profile-2
+```
+
+## Reporting
+
+### Test Report Template
+```
+AuthAWS Flag-Based Parameters Test Report
+========================================
+
+Test Date: [DATE]
+Tester: [NAME]
+Environment: [OS/Version]
+
+Summary:
+- Total Tests: [NUMBER]
+- Passed: [NUMBER]
+- Failed: [NUMBER]
+- Skipped: [NUMBER]
+
+Key Findings:
+- [List any issues found]
+- [Performance observations]
+- [User experience notes]
+
+Recommendations:
+- [Any changes needed]
+- [Additional testing required]
+
+Status: [PASS/FAIL/NEEDS_REVISION]
+```
+
+## Maintenance
+
+### Ongoing Testing
+- Run regression tests after any authaws changes
+- Test new flag combinations as they're added
+- Monitor performance impact over time
+- Update test cases for new features
+
+### Test Case Updates
+- Add test cases for new flags
+- Update expected results for changed behavior
+- Remove obsolete test cases
+- Add performance benchmarks for new features


### PR DESCRIPTION
- Remove hardcoded region validation fallback as requested
- Always source regions.sh module for region validation
- Improve SSO URL validation to support custom domains (per Copilot feedback)
- Add regions.sh sourcing to authaws script for proper region validation
- Update QA test documentation with security warnings
- Ensure validate_region_code function is always available
- Maintain strict region validation using short codes (use1, cac1, etc.)