### PR TITLE
feat: Add flag-based parameters support to SSM tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## [v1.6.0] - 2025-08-19
+
+### Added
+- **Flag-based parameter support for SSM tool** - New enterprise-friendly syntax with `--region`, `--instance`, `--command` flags
+- **Mixed syntax support** - Combination of positional and flag-based parameters (e.g., `ssm cac1 --instance i-1234`)
+- **Enhanced user experience** - Self-documenting commands with clear parameter names
+- **Professional installation system** - New Makefile with `make install`, `make dev`, `make test` targets
+- **Short flag support** - `-h`, `-v`, `-r`, `-i` for common operations
+- **Comprehensive parameter parser** - New `src/07_ssm_parameter_parser.sh` module following established patterns
+- **Enhanced error messages** - Actionable guidance for missing modules and setup issues
+
+### Changed
+- **Backward compatibility maintained** - All existing positional syntax continues to work unchanged
+- **Dynamic command naming** - Both `ssm` and `authaws` now use `$(basename "$0")` for consistent help text
+- **Improved documentation** - Updated README.md with clear user vs developer installation paths
+- **Enhanced testing** - New `tests/QA_SSM_TESTS.md` with comprehensive test scenarios
+
+### Fixed
+- **Critical port forwarding bug** - Fixed instance name resolution for port forwarding operations
+- **Region validation consistency** - Resolved inconsistent region validation across different SSM commands
+- **Duplicate PATH prevention** - Fixed Makefile to prevent duplicate PATH entries in development setup
+- **Shellcheck compliance** - Resolved all linting warnings (SC2034, SC2155)
+
 ## [v2.1.0] - 2025-08-04
 
 ### Added

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -250,9 +250,50 @@ If updating from pre-March 2025 (when repository was named "quickssm"), see [doc
 
 If you need to use the legacy bash tools:
 
-**Installation:**
+### **For End Users (Simple Installation):**
+
 ```bash
-# Clone repository (required - bash tools cannot be downloaded as binaries)
+# Step 1: Download
+git clone https://github.com/zsoftly/ztiaws.git
+cd ztiaws
+
+# Step 2: Install (no build tools required)
+./install.sh
+
+# Step 3: Verify
+authaws --check
+ssm --help
+```
+
+The installation script automatically:
+- ✅ Installs `authaws` and `ssm` commands globally
+- ✅ Copies all required modules to `/usr/local/bin/src/`
+- ✅ Sets up proper permissions
+- ✅ Verifies installation works correctly
+
+**To uninstall:** `./uninstall.sh`
+
+### **For Developers (Development Setup):**
+
+```bash
+# Clone repository
+git clone https://github.com/zsoftly/ztiaws.git
+cd ztiaws
+
+# Development environment setup
+make dev          # Sets up development environment
+make test         # Run shellcheck and basic tests
+make clean        # Clean up temporary files
+
+# Development testing
+./authaws --check  # Test local development version
+./ssm --help       # Test local development version
+```
+
+### **Manual Installation (Alternative):**
+
+```bash
+# Clone repository
 git clone https://github.com/zsoftly/ztiaws.git
 cd ztiaws
 

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,8 @@ dev:
 test:
 	@echo "Running shellcheck..."
 	shellcheck -x authaws ssm src/*.sh
-	@echo "Running basic functionality tests..."
+	@echo "Running development functionality tests..."
+	@echo "  (Using ./command syntax to test local development versions)"
 	./authaws --help > /dev/null
 	./ssm --help > /dev/null
 	@echo "✅ Tests passed!"

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ uninstall:
 dev:
 	@echo "Setting up development environment..."
 	@echo "Adding current directory to PATH for this session..."
-	@echo "export PATH=\"$(PWD):\$$PATH\"" >> ~/.zshrc
-	@echo "export PATH=\"$(PWD):\$$PATH\"" >> ~/.bashrc
+	@grep -qxF 'export PATH="$(PWD):$$PATH"' ~/.zshrc || echo 'export PATH="$(PWD):$$PATH"' >> ~/.zshrc
+	@grep -qxF 'export PATH="$(PWD):$$PATH"' ~/.bashrc || echo 'export PATH="$(PWD):$$PATH"' >> ~/.bashrc
 	@echo ""
 	@echo "✅ Development environment configured!"
 	@echo "Reload your shell or run: source ~/.zshrc"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,69 @@
+# ZTiAWS Makefile
+# Simple installation and development management
+
+.PHONY: install uninstall dev clean test help
+
+# Default target
+help:
+	@echo "ZTiAWS - AWS Tools Installation"
+	@echo ""
+	@echo "Available targets:"
+	@echo "  install    - Install authaws and ssm to /usr/local/bin (global access)"
+	@echo "  uninstall  - Remove installed tools from /usr/local/bin"
+	@echo "  dev        - Set up development environment (adds local PATH)"
+	@echo "  test       - Run tests and validation"
+	@echo "  clean      - Clean up temporary files"
+	@echo "  help       - Show this help message"
+	@echo ""
+	@echo "Quick start:"
+	@echo "  make install    # Install globally (recommended)"
+	@echo "  authaws --check # Test installation"
+
+# Install tools globally to /usr/local/bin
+install:
+	@echo "Installing ZTiAWS tools to /usr/local/bin..."
+	sudo cp authaws /usr/local/bin/authaws
+	sudo cp ssm /usr/local/bin/ssm
+	sudo chmod +x /usr/local/bin/authaws /usr/local/bin/ssm
+	@echo "Creating source directory..."
+	sudo mkdir -p /usr/local/bin/src
+	sudo cp src/*.sh /usr/local/bin/src/
+	sudo chmod +x /usr/local/bin/src/*.sh
+	@echo ""
+	@echo "✅ Installation complete!"
+	@echo "You can now run 'authaws --check' and 'ssm --help' from anywhere."
+
+# Remove installed tools
+uninstall:
+	@echo "Removing ZTiAWS tools from /usr/local/bin..."
+	sudo rm -f /usr/local/bin/authaws
+	sudo rm -f /usr/local/bin/ssm
+	sudo rm -rf /usr/local/bin/src
+	@echo "✅ Uninstallation complete!"
+
+# Development environment setup
+dev:
+	@echo "Setting up development environment..."
+	@echo "Adding current directory to PATH for this session..."
+	@echo "export PATH=\"$(PWD):\$$PATH\"" >> ~/.zshrc
+	@echo "export PATH=\"$(PWD):\$$PATH\"" >> ~/.bashrc
+	@echo ""
+	@echo "✅ Development environment configured!"
+	@echo "Reload your shell or run: source ~/.zshrc"
+	@echo "Then you can use 'authaws --check' directly in development."
+
+# Run tests
+test:
+	@echo "Running shellcheck..."
+	shellcheck -x authaws ssm src/*.sh
+	@echo "Running basic functionality tests..."
+	./authaws --help > /dev/null
+	./ssm --help > /dev/null
+	@echo "✅ Tests passed!"
+
+# Clean up
+clean:
+	@echo "Cleaning up temporary files..."
+	find . -name "*.log" -delete
+	find . -name ".DS_Store" -delete
+	@echo "✅ Cleanup complete!"

--- a/README.md
+++ b/README.md
@@ -38,26 +38,34 @@
 
 ## ⚡ Installation
 
-**Quick Install (Recommended):**
+### **Quick Install (Recommended):**
+
+**For Users:**
+```bash
+git clone https://github.com/zsoftly/ztiaws.git
+cd ztiaws
+make install
+```
+
+**Verify Installation:**
+```bash
+authaws --check
+ssm --help
+```
+
+**For Developers:**
+```bash
+git clone https://github.com/zsoftly/ztiaws.git
+cd ztiaws
+make dev          # Sets up development environment
+authaws --check   # Works without ./ prefix
+```
 
 See [INSTALLATION.md](INSTALLATION.md) for comprehensive installation instructions including:
-- One-liner installers for Linux/macOS/Windows
-- Platform-specific instructions
+- Platform-specific instructions  
 - Windows PATH setup (detailed)
-- Legacy bash tools installation
+- ztictl Go binary installation
 - Troubleshooting guide
-
-**Essential commands after installation:**
-```bash
-# Verify installation
-ztictl --version
-
-# Check system requirements
-ztictl config check
-
-# Get started
-ztictl --help
-```
 
 ## 🔄 Updating ZTiAWS
 

--- a/README.md
+++ b/README.md
@@ -111,37 +111,91 @@ ztictl ssm --help
 
 #### SSM Session Manager Tool
 
+**Available flags**: `--region`, `--instance`, `--command`, `--tag-key`, `--tag-value`, `--local-file`, `--remote-file`, `--local-path`, `--remote-path`, `--local-port`, `--remote-port`, `--exec`, `--exec-tagged`, `--upload`, `--download`, `--forward`, `--list`, `--connect`, `--check`, `--help`, `--version`, `--debug`
+
 ##### Check System Requirements
 ```bash
+# Traditional syntax (backward compatible)
 ssm check
+
+# Flag-based syntax (new)
+ssm --check
 ```
 
 ##### List Instances in a Region
 ```bash
+# Traditional syntax (backward compatible)
 ssm cac1  # Lists instances in Canada Central
+
+# Flag-based syntax (new)
+ssm --region cac1 --list
+ssm --region cac1  # Equivalent to --list
 ```
 
 ##### Connect to an Instance
 ```bash
+# Traditional syntax (backward compatible)
 ssm i-1234abcd              # Connect to instance in default region (Canada Central)
 ssm use1 i-1234abcd         # Connect to instance in US East
+
+# Flag-based syntax (new)
+ssm --region use1 --instance i-1234abcd --connect
+ssm --region use1 --instance i-1234abcd  # Equivalent to --connect
+
+# Mixed syntax (also supported)
+ssm cac1 --instance i-1234abcd
+ssm --region use1 i-1234abcd
 ```
 
 ##### Execute Commands Remotely
 Execute commands on a single instance:
 ```bash
+# Traditional syntax (backward compatible)
 ssm exec cac1 i-1234 "systemctl status nginx"
+
+# Flag-based syntax (new)
+ssm --exec --region cac1 --instance i-1234 --command "systemctl status nginx"
+
+# Mixed syntax (also supported)
+ssm exec cac1 --instance i-1234 --command "systemctl status nginx"
 ```
 
 Execute commands on instances matching specific tags:
 ```bash
+# Traditional syntax (backward compatible)
 ssm exec-tagged use1 Role web "df -h"
+
+# Flag-based syntax (new)
+ssm --exec-tagged --region use1 --tag-key Role --tag-value web --command "df -h"
+
+# Mixed syntax (also supported)
+ssm exec-tagged use1 --tag-key Role --tag-value web --command "df -h"
 ```
 This will run `df -h` on all instances in the `us-east-1` region that have a tag with `Key=Role` and `Value=web`. The script provides clear feedback if no instances match the specified tags.
 
+##### File Transfer Operations
+Upload and download files with automatic size-based routing:
+```bash
+# Traditional syntax (backward compatible)
+ssm upload cac1 i-1234 ./config.txt /etc/app/config.txt
+ssm download cac1 i-1234 /var/log/app.log ./app.log
+
+# Flag-based syntax (new)
+ssm --upload --region cac1 --instance i-1234 --local-file ./config.txt --remote-path /etc/app/config.txt
+ssm --download --region cac1 --instance i-1234 --remote-file /var/log/app.log --local-path ./app.log
+
+# Mixed syntax (also supported)
+ssm upload cac1 --instance i-1234 --local-file ./config.txt --remote-path /etc/app/config.txt
+```
+
 ##### Show Help
 ```bash
+# Traditional syntax (backward compatible)
 ssm help
+
+# Flag-based syntax (new)
+ssm --help
+ssm -h
 ```
 
 #### AWS SSO Authentication Tool

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ make dev          # Sets up development environment
 authaws --check   # Works without ./ prefix
 ```
 
+**Development Testing:**
+```bash
+# Test local development versions (before installation)
+./authaws --check
+./ssm --help
+
+# After make install or make dev
+authaws --check
+ssm --help
+```
+
 See [INSTALLATION.md](INSTALLATION.md) for comprehensive installation instructions including:
 - Platform-specific instructions  
 - Windows PATH setup (detailed)

--- a/README.md
+++ b/README.md
@@ -38,27 +38,49 @@
 
 ## ⚡ Installation
 
-### **Quick Install (Recommended):**
+### **For End Users (Simple Installation):**
 
-**For Users:**
+**Step 1: Download**
 ```bash
 git clone https://github.com/zsoftly/ztiaws.git
 cd ztiaws
-make install
 ```
 
-**Verify Installation:**
+**Step 2: Install**
+```bash
+./install.sh
+```
+
+**Step 3: Verify**
 ```bash
 authaws --check
 ssm --help
 ```
 
-**For Developers:**
+The installation script automatically:
+- ✅ Installs `authaws` and `ssm` commands globally
+- ✅ Copies all required modules to `/usr/local/bin/src/`
+- ✅ Sets up proper permissions
+- ✅ Verifies installation works correctly
+
+**To uninstall:** `./uninstall.sh`
+
+---
+
+### **For Developers (Advanced Setup):**
+
+**Development Environment:**
 ```bash
 git clone https://github.com/zsoftly/ztiaws.git
 cd ztiaws
 make dev          # Sets up development environment
-authaws --check   # Works without ./ prefix
+```
+
+**Development Tools:**
+```bash
+make test         # Run shellcheck and basic tests
+make clean        # Clean up temporary files
+make help         # Show all available targets
 ```
 
 **Development Testing:**
@@ -67,10 +89,12 @@ authaws --check   # Works without ./ prefix
 ./authaws --check
 ./ssm --help
 
-# After make install or make dev
+# After make dev or make install
 authaws --check
 ssm --help
 ```
+
+**Note for Developers:** Use `make` targets for development workflow. End users should use `./install.sh` for simpler installation without requiring build tools.
 
 See [INSTALLATION.md](INSTALLATION.md) for comprehensive installation instructions including:
 - Platform-specific instructions  

--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,30 @@
+# ZTiAWS Bash Scripts v1.6.0 Release Notes
+
+**Installation:** [Installation Guide](https://github.com/zsoftly/ztiaws/blob/main/README.md)
+
+**Release Date:** August 19, 2025
+
+## 🚀 New Features
+• **Flag-based parameter support for SSM tool** - Enterprise-friendly syntax with `--region`, `--instance`, `--command` flags
+• **Mixed syntax support** - Combine positional and flag-based parameters (e.g., `ssm cac1 --instance i-1234`)
+• **Professional installation system** - New Makefile with `make install`, `make dev`, `make test` targets
+• **Short flag support** - `-h`, `-v`, `-r`, `-i` for common operations
+• **Enhanced error messages** - Actionable guidance for missing modules and setup issues
+
+## 🐛 Bug Fixes
+• **Critical port forwarding bug** - Fixed instance name resolution for port forwarding operations
+• **Region validation consistency** - Resolved inconsistent region validation across different SSM commands
+• **Duplicate PATH prevention** - Fixed Makefile to prevent duplicate PATH entries in development setup
+• **Shellcheck compliance** - Resolved all linting warnings (SC2034, SC2155)
+
+## 📝 Other Changes
+• **Backward compatibility maintained** - All existing positional syntax continues to work unchanged
+• **Dynamic command naming** - Both `ssm` and `authaws` now use `$(basename "$0")` for consistent help text
+• **Improved documentation** - Updated README.md with clear user vs developer installation paths
+• **Enhanced testing** - New `tests/QA_SSM_TESTS.md` with comprehensive test scenarios
+
+---
+
 # ztictl v2.1.0 Release Notes
 
 **Installation:** [Installation Guide](https://github.com/zsoftly/ztiaws/blob/release/v2.1.0/INSTALLATION.md)

--- a/authaws
+++ b/authaws
@@ -94,22 +94,22 @@ EOL
 
 # Display help information
 show_help() {
-  cat << 'EOL'
+  cat << EOL
 AWS SSO Authentication Helper
 
 USAGE:
-  authaws [profile-name]                    # Positional syntax (backward compatible)
-  authaws --profile <name>                  # Flag-based syntax (enterprise friendly)
+  $(basename "$0") [profile-name]                    # Positional syntax (backward compatible)
+  $(basename "$0") --profile <name>                  # Flag-based syntax (enterprise friendly)
 
 COMMANDS:
-  authaws help                              # Show this help message
-  authaws --help, -h                        # Show this help message
-  authaws version                           # Show version information
-  authaws --version, -v                     # Show version information
-  authaws check                             # Check system requirements
-  authaws --check                           # Check system requirements
-  authaws creds [profile]                   # Show decoded credentials for a profile
-  authaws --creds [--profile <name>]        # Show decoded credentials for a profile
+  $(basename "$0") help                              # Show this help message
+  $(basename "$0") --help, -h                        # Show this help message
+  $(basename "$0") version                           # Show version information
+  $(basename "$0") --version, -v                     # Show version information
+  $(basename "$0") check                             # Check system requirements
+  $(basename "$0") --check                           # Check system requirements
+  $(basename "$0") creds [profile]                   # Show decoded credentials for a profile
+  $(basename "$0") --creds [--profile <name>]        # Show decoded credentials for a profile
 
 FLAGS:
   --profile, -p <name>                      # Profile name to use
@@ -121,19 +121,19 @@ FLAGS:
 
 EXAMPLES:
   # Power user workflow (current syntax)
-  authaws                                  # Show help (no profile specified)
-  authaws dev-profile                      # Login with specific profile
-  authaws check                            # Verify dependencies
-  authaws creds dev-profile                # Show credentials for a profile
+  $(basename "$0")                                  # Show help (no profile specified)
+  $(basename "$0") dev-profile                      # Login with specific profile
+  $(basename "$0") check                            # Verify dependencies
+  $(basename "$0") creds dev-profile                # Show credentials for a profile
 
   # Enterprise workflow (new syntax)
-  authaws --profile dev-profile            # Login with specific profile
-  authaws --profile prod --region us-east-1 # Override region
-  authaws --creds --profile dev-profile    # Show credentials for a profile
-  authaws --profile dev --export           # Export credentials to stdout
+  $(basename "$0") --profile dev-profile            # Login with specific profile
+  $(basename "$0") --profile prod --region us-east-1 # Override region
+  $(basename "$0") --creds --profile dev-profile    # Show credentials for a profile
+  $(basename "$0") --profile dev --export           # Export credentials to stdout
 
   # Future extensibility
-  authaws --profile dev --sso-url https://alt.awsapps.com/start
+  $(basename "$0") --profile dev --sso-url https://alt.awsapps.com/start
 
 SETUP:
   Before first use, create a .env file in the script directory with:

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,11 @@ install_files() {
     print_color $BLUE "  • Installing source modules..."
     $install_cmd cp src/*.sh /usr/local/bin/src/
     
+    # Create XDG-compliant configuration directory for enterprise standards
+    print_color $BLUE "  • Setting up configuration directory..."
+    local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ztiaws"
+    mkdir -p "$config_dir" 2>/dev/null || true
+    
     print_color $GREEN "✅ Files installed successfully!"
     echo
 }

--- a/install.sh
+++ b/install.sh
@@ -80,11 +80,6 @@ install_files() {
     print_color $BLUE "  • Installing source modules..."
     $install_cmd cp src/*.sh /usr/local/bin/src/
     
-    # Create XDG-compliant configuration directory for enterprise standards
-    print_color $BLUE "  • Setting up configuration directory..."
-    local config_dir="${XDG_CONFIG_HOME:-$HOME/.config}/ztiaws"
-    mkdir -p "$config_dir" 2>/dev/null || true
-    
     print_color $GREEN "✅ Files installed successfully!"
     echo
 }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+
+# ZTiAWS Installation Script
+# Simple installation for end users (no make required)
+
+set -e  # Exit on any error
+
+# Color output for better UX
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_color() {
+    local color=$1
+    local message=$2
+    echo -e "${color}${message}${NC}"
+}
+
+# Function to check if running as root/sudo
+check_permissions() {
+    if [[ $EUID -eq 0 ]]; then
+        print_color $YELLOW "Warning: Running as root. This is not recommended for security reasons."
+        print_color $YELLOW "Consider running without sudo and entering password when prompted."
+        echo
+    fi
+}
+
+# Function to check system requirements
+check_requirements() {
+    print_color $BLUE "🔍 Checking system requirements..."
+    
+    # Check if AWS CLI is installed
+    if ! command -v aws &> /dev/null; then
+        print_color $RED "❌ AWS CLI is not installed"
+        print_color $YELLOW "Please install AWS CLI first:"
+        print_color $YELLOW "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+        exit 1
+    else
+        local aws_version=$(aws --version 2>&1 | cut -d/ -f2 | cut -d' ' -f1)
+        print_color $GREEN "✅ AWS CLI found (version: $aws_version)"
+    fi
+    
+    # Check if we have write permissions to /usr/local/bin
+    if [[ ! -w "/usr/local/bin" ]]; then
+        print_color $YELLOW "⚠️  /usr/local/bin is not writable. Will need sudo for installation."
+        USE_SUDO=true
+    else
+        USE_SUDO=false
+    fi
+    
+    echo
+}
+
+# Function to install files
+install_files() {
+    print_color $BLUE "📦 Installing ZTiAWS files..."
+    
+    local install_cmd=""
+    if [[ $USE_SUDO == true ]]; then
+        install_cmd="sudo"
+        print_color $YELLOW "🔐 Administrator privileges required for installation..."
+    fi
+    
+    # Create src directory if it doesn't exist
+    $install_cmd mkdir -p /usr/local/bin/src
+    
+    # Copy main scripts
+    print_color $BLUE "  • Installing authaws..."
+    $install_cmd cp authaws /usr/local/bin/
+    $install_cmd chmod +x /usr/local/bin/authaws
+    
+    print_color $BLUE "  • Installing ssm..."
+    $install_cmd cp ssm /usr/local/bin/
+    $install_cmd chmod +x /usr/local/bin/ssm
+    
+    # Copy source modules
+    print_color $BLUE "  • Installing source modules..."
+    $install_cmd cp src/*.sh /usr/local/bin/src/
+    
+    print_color $GREEN "✅ Files installed successfully!"
+    echo
+}
+
+# Function to verify installation
+verify_installation() {
+    print_color $BLUE "🧪 Verifying installation..."
+    
+    # Test authaws
+    if command -v authaws &> /dev/null; then
+        print_color $GREEN "✅ authaws command available"
+        local authaws_version=$(authaws --version 2>/dev/null | head -n1)
+        print_color $BLUE "   Version: $authaws_version"
+    else
+        print_color $RED "❌ authaws command not found"
+        return 1
+    fi
+    
+    # Test ssm
+    if command -v ssm &> /dev/null; then
+        print_color $GREEN "✅ ssm command available" 
+        local ssm_version=$(ssm --version 2>/dev/null | head -n1)
+        print_color $BLUE "   Version: $ssm_version"
+    else
+        print_color $RED "❌ ssm command not found"
+        return 1
+    fi
+    
+    echo
+    print_color $GREEN "🎉 Installation verification successful!"
+    return 0
+}
+
+# Function to show next steps
+show_next_steps() {
+    print_color $BLUE "🚀 Next Steps:"
+    echo
+    print_color $YELLOW "1. Verify your AWS configuration:"
+    echo "   authaws --check"
+    echo
+    print_color $YELLOW "2. Check SSM requirements:"
+    echo "   ssm --check"
+    echo
+    print_color $YELLOW "3. Get help:"
+    echo "   authaws --help"
+    echo "   ssm --help"
+    echo
+    print_color $YELLOW "4. Quick start example:"
+    echo "   # Authenticate with AWS SSO"
+    echo "   authaws your-profile-name"
+    echo
+    echo "   # List EC2 instances in Canada Central"
+    echo "   ssm --region cac1 --list"
+    echo
+    print_color $BLUE "📚 Documentation: https://github.com/zsoftly/ztiaws"
+    echo
+}
+
+# Function to show uninstall instructions
+show_uninstall_info() {
+    print_color $BLUE "🗑️  To uninstall ZTiAWS in the future:"
+    echo "   sudo rm -f /usr/local/bin/authaws"
+    echo "   sudo rm -f /usr/local/bin/ssm" 
+    echo "   sudo rm -rf /usr/local/bin/src"
+    echo
+}
+
+# Main installation function
+main() {
+    print_color $GREEN "🚀 ZTiAWS Installation"
+    print_color $BLUE "======================================"
+    echo
+    print_color $BLUE "Installing ZTiAWS (ZSoftly Tools for AWS)"
+    print_color $BLUE "Legacy bash tools for AWS SSM and SSO management"
+    echo
+    
+    # Check if we're in the right directory
+    if [[ ! -f "authaws" ]] || [[ ! -f "ssm" ]] || [[ ! -d "src" ]]; then
+        print_color $RED "❌ Installation files not found in current directory"
+        print_color $YELLOW "Please run this script from the ZTiAWS project directory"
+        print_color $YELLOW "Expected files: authaws, ssm, src/"
+        exit 1
+    fi
+    
+    check_permissions
+    check_requirements
+    install_files
+    
+    if verify_installation; then
+        show_next_steps
+        show_uninstall_info
+        print_color $GREEN "✅ ZTiAWS installation completed successfully!"
+    else
+        print_color $RED "❌ Installation verification failed"
+        print_color $YELLOW "Please check the error messages above and try again"
+        exit 1
+    fi
+}
+
+# Show help if requested
+if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    print_color $GREEN "ZTiAWS Installation Script"
+    echo
+    print_color $BLUE "USAGE:"
+    echo "  ./install.sh         # Install ZTiAWS"
+    echo "  ./install.sh --help  # Show this help"
+    echo
+    print_color $BLUE "DESCRIPTION:"
+    echo "  Installs ZTiAWS bash tools (authaws, ssm) to /usr/local/bin"
+    echo "  for global access. No build tools or dependencies required."
+    echo
+    print_color $BLUE "REQUIREMENTS:"
+    echo "  • AWS CLI (https://aws.amazon.com/cli/)"
+    echo "  • Write access to /usr/local/bin (may require sudo)"
+    echo
+    print_color $BLUE "FOR DEVELOPERS:"
+    echo "  Use 'make dev' instead for development environment setup"
+    echo
+    exit 0
+fi
+
+# Run main installation
+main "$@"

--- a/src/00_version.sh
+++ b/src/00_version.sh
@@ -3,6 +3,6 @@
 # Shared version information for ztiaws project
 # This is the single source of truth for version management
 
-export ZTIAWS_VERSION="1.5.0"
-export ZTIAWS_BUILD_DATE="2025-07-31"
+export ZTIAWS_VERSION="1.6.0"
+export ZTIAWS_BUILD_DATE="2025-08-19"
 export ZTIAWS_PROJECT_NAME="ztiaws"

--- a/src/00_version.sh
+++ b/src/00_version.sh
@@ -4,5 +4,5 @@
 # This is the single source of truth for version management
 
 export ZTIAWS_VERSION="1.6.0"
-export ZTIAWS_BUILD_DATE="2025-08-19"
+export ZTIAWS_BUILD_DATE="2025-08-27"
 export ZTIAWS_PROJECT_NAME="ztiaws"

--- a/src/01_regions.sh
+++ b/src/01_regions.sh
@@ -62,6 +62,78 @@ validate_region_code() {
     fi
 }
 
+# Validate actual AWS region name (full region name, not shortcode)
+# Returns 0 if valid AWS region, 1 if invalid
+# Usage: if validate_aws_region "us-east-1"; then ... fi
+validate_aws_region() {
+    local region="$1"
+    
+    # Check if region is provided
+    if [[ -z "$region" ]]; then
+        return 1
+    fi
+    
+    # List of all valid AWS regions (as of 2025)
+    local valid_regions=(
+        # US Regions
+        "us-east-1"      # N. Virginia
+        "us-east-2"      # Ohio
+        "us-west-1"      # N. California
+        "us-west-2"      # Oregon
+        
+        # Canada Regions
+        "ca-central-1"   # Montreal
+        "ca-west-1"      # Calgary
+        
+        # Europe Regions
+        "eu-west-1"      # Ireland
+        "eu-west-2"      # London
+        "eu-west-3"      # Paris
+        "eu-central-1"   # Frankfurt
+        "eu-central-2"   # Zurich
+        "eu-north-1"     # Stockholm
+        "eu-south-1"     # Milan
+        "eu-south-2"     # Spain
+        
+        # Asia Pacific Regions
+        "ap-south-1"     # Mumbai
+        "ap-south-2"     # Hyderabad
+        "ap-southeast-1" # Singapore
+        "ap-southeast-2" # Sydney
+        "ap-southeast-3" # Jakarta
+        "ap-southeast-4" # Melbourne
+        "ap-northeast-1" # Tokyo
+        "ap-northeast-2" # Seoul
+        "ap-northeast-3" # Osaka
+        "ap-east-1"      # Hong Kong
+        
+        # Middle East & Africa
+        "me-south-1"     # Bahrain
+        "me-central-1"   # UAE
+        "af-south-1"     # Cape Town
+        
+        # South America
+        "sa-east-1"      # São Paulo
+        
+        # China (special regions)
+        "cn-north-1"     # Beijing
+        "cn-northwest-1" # Ningxia
+        
+        # GovCloud (US)
+        "us-gov-east-1" # AWS GovCloud (US-East)
+        "us-gov-west-1" # AWS GovCloud (US-West)
+    )
+    
+    # Check if the provided region exists in our list
+    for valid_region in "${valid_regions[@]}"; do
+        if [[ "$region" == "$valid_region" ]]; then
+            return 0  # Valid region found
+        fi
+    done
+    
+    return 1  # Invalid region
+}
+
 # Get region description
 get_region_description() {
     case "$1" in

--- a/src/07_ssm_parameter_parser.sh
+++ b/src/07_ssm_parameter_parser.sh
@@ -10,9 +10,21 @@
 # Environment Variables:
 # - SSM_DEFAULT_REGION: Override default region (default: ca-central-1)
 #   Example: export SSM_DEFAULT_REGION="us-east-1"
+# - ZTIAWS_DEFAULT_REGION: Alternative environment variable name
+# 
+# .env file support: Create .env file in script directory with environment variables
 # 
 # Compatibility: bash 3.2+ (macOS compatible)
 # Usage: source this file in ssm script, then call parse_ssm_parameters "$@"
+
+# Load .env file if it exists (simple approach)
+if [[ -f "$(dirname "${BASH_SOURCE[0]}")/../.env" ]]; then
+    # shellcheck source=/dev/null
+    source "$(dirname "${BASH_SOURCE[0]}")/../.env"
+elif [[ -f ".env" ]]; then
+    # shellcheck source=/dev/null
+    source ".env"
+fi
 
 # Global variables to store parsed parameters
 # Using regular variable assignment for bash 3.2 compatibility
@@ -221,7 +233,7 @@ parse_positional_parameters() {
             else
                 # Assume it's an instance identifier for default region
                 SSM_OPERATION="connect"
-                SSM_REGION="${SSM_DEFAULT_REGION:-ca-central-1}"  # Default region from environment
+                SSM_REGION="${SSM_DEFAULT_REGION:-${ZTIAWS_DEFAULT_REGION:-ca-central-1}}"  # Simple environment variable approach
                 SSM_INSTANCE="$first_arg"
                 return 0
             fi
@@ -561,7 +573,8 @@ validate_and_infer_operation() {
     
     # Set default region if not specified and operation requires it
     if [[ -z "$SSM_REGION" && "$SSM_OPERATION" =~ ^(connect|exec|exec-tagged|upload|download|forward|list)$ ]]; then
-        SSM_REGION="${SSM_DEFAULT_REGION:-ca-central-1}"  # Default region from environment
+        # Simple environment variable approach
+        SSM_REGION="${SSM_DEFAULT_REGION:-${ZTIAWS_DEFAULT_REGION:-ca-central-1}}"
     fi
     
     # Validate required parameters for each operation

--- a/src/07_ssm_parameter_parser.sh
+++ b/src/07_ssm_parameter_parser.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 # SSM Parameter Parser Module
-# Version: 1.0.0
 # Repository: https://github.com/ZSoftly/ztiaws
 # 
 # This module provides unified parameter parsing for ssm, supporting both

--- a/src/07_ssm_parameter_parser.sh
+++ b/src/07_ssm_parameter_parser.sh
@@ -231,11 +231,20 @@ parse_positional_parameters() {
                 fi
                 return 0
             else
-                # Assume it's an instance identifier for default region
-                SSM_OPERATION="connect"
-                SSM_REGION="${SSM_DEFAULT_REGION:-${ZTIAWS_DEFAULT_REGION:-ca-central-1}}"  # Simple environment variable approach
-                SSM_INSTANCE="$first_arg"
-                return 0
+                # Validate that the argument looks like a valid instance identifier before assuming it's an instance
+                if [[ "$first_arg" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+                    # Looks like instance ID (i-xxxxxxxx)
+                    SSM_OPERATION="connect"
+                    SSM_REGION="${SSM_DEFAULT_REGION:-${ZTIAWS_DEFAULT_REGION:-ca-central-1}}"  # Simple environment variable approach
+                    SSM_INSTANCE="$first_arg"
+                    return 0
+                else
+                    # Invalid argument format
+                    log_error "Error: Unrecognized argument '$first_arg'"
+                    log_error "Expected: region code (e.g., 'cac1', 'use1') or instance ID (e.g., 'i-1234567890abcdef0')"
+                    log_error "Use '$(basename "$0") --help' for usage information"
+                    return 1
+                fi
             fi
             ;;
     esac

--- a/src/07_ssm_parameter_parser.sh
+++ b/src/07_ssm_parameter_parser.sh
@@ -1,0 +1,709 @@
+#!/usr/bin/env bash
+
+# SSM Parameter Parser Module
+# Version: 1.0.0
+# Repository: https://github.com/ZSoftly/ztiaws
+# 
+# This module provides unified parameter parsing for ssm, supporting both
+# positional and flag-based syntax while maintaining full backward compatibility.
+# 
+# Compatibility: bash 3.2+ (macOS compatible)
+# Usage: source this file in ssm script, then call parse_ssm_parameters "$@"
+
+# Global variables to store parsed parameters
+# Using regular variable assignment for bash 3.2 compatibility
+SSM_REGION=""
+SSM_INSTANCE=""
+SSM_COMMAND=""
+SSM_TAG_KEY=""
+SSM_TAG_VALUE=""
+SSM_LOCAL_FILE=""
+SSM_REMOTE_FILE=""
+SSM_LOCAL_PATH=""
+SSM_REMOTE_PATH=""
+SSM_LOCAL_PORT=""
+SSM_REMOTE_PORT=""
+SSM_OPERATION=""  # connect, list, exec, exec-tagged, upload, download, forward, check, version, help
+SSM_HELP="false"
+SSM_VERSION="false"
+SSM_CHECK="false"
+SSM_DEBUG="false"
+
+# Function to detect if arguments contain flags
+has_flags() {
+    local args=("$@")
+    for arg in "${args[@]}"; do
+        if [[ "$arg" =~ ^- ]]; then
+            return 0  # Found a flag
+        fi
+    done
+    return 1  # No flags found
+}
+
+# Function to show parameter parser help
+show_parameter_help() {
+    cat << 'EOL'
+SSM Parameter Parser Help
+
+This module supports both positional and flag-based parameter syntax:
+
+POSITIONAL SYNTAX (current - backward compatible):
+  ssm [region]                     # List instances in region
+  ssm [region] [instance]          # Connect to instance
+  ssm exec [region] [instance] [command]    # Execute command
+  ssm upload [region] [instance] [local] [remote]  # Upload file
+  ssm download [region] [instance] [remote] [local]  # Download file
+  ssm check                        # Check system requirements
+  ssm version                      # Show version
+  ssm help                         # Show help
+
+FLAG-BASED SYNTAX (new - enterprise friendly):
+  ssm --region [region]            # List instances in region
+  ssm --region [region] --instance [instance]  # Connect to instance
+  ssm --exec --region [region] --instance [instance] --command [command]  # Execute command
+  ssm --upload --region [region] --instance [instance] --local-file [local] --remote-path [remote]  # Upload file
+  ssm --download --region [region] --instance [instance] --remote-file [remote] --local-path [local]  # Download file
+  ssm --check                      # Check system requirements
+  ssm --version                    # Show version
+  ssm --help                       # Show help
+
+MIXED SYNTAX (also supported):
+  ssm cac1 --instance i-1234567890abcd
+  ssm --region cac1 i-1234567890abcd
+
+AVAILABLE FLAGS:
+  --region, -r <region>            # AWS region or region code
+  --instance, -i <instance>        # Instance ID or name
+  --command, -c <command>          # Command to execute
+  --tag-key <key>                  # Tag key for exec-tagged
+  --tag-value <value>              # Tag value for exec-tagged
+  --local-file <path>              # Local file path for upload
+  --remote-file <path>             # Remote file path for download
+  --local-path <path>              # Local path for download
+  --remote-path <path>             # Remote path for upload
+  --local-port <port>              # Local port for forwarding
+  --remote-port <port>             # Remote port for forwarding
+  --exec                           # Execute command operation
+  --exec-tagged                    # Execute command on tagged instances
+  --upload                         # Upload file operation
+  --download                       # Download file operation
+  --forward                        # Port forwarding operation
+  --list                           # List instances operation
+  --connect                        # Connect to instance operation
+  --check                          # Check system requirements
+  --help, -h                       # Show help
+  --version, -v                    # Show version
+  --debug                          # Enable debug mode
+
+EXAMPLES:
+  # Power user workflow (current syntax)
+  ssm cac1                         # List instances in Canada Central
+  ssm cac1 i-1234                  # Connect to instance
+  ssm exec cac1 i-1234 "uptime"    # Execute command
+
+  # Enterprise workflow (new syntax)
+  ssm --region cac1 --list         # List instances
+  ssm --region cac1 --instance i-1234 --connect  # Connect to instance
+  ssm --exec --region cac1 --instance i-1234 --command "uptime"  # Execute command
+
+  # Mixed workflow
+  ssm cac1 --instance i-1234       # List region with specific instance
+  ssm --region cac1 i-1234         # Use flag for region, positional for instance
+EOL
+}
+
+# Function to parse positional parameters (current behavior)
+parse_positional_parameters() {
+    local args=("$@")
+    
+    if [[ ${#args[@]} -eq 0 ]]; then
+        # No arguments - show help
+        SSM_HELP="true"
+        SSM_OPERATION="help"
+        return 0
+    fi
+    
+    local first_arg="${args[0]}"
+    
+    # Check for commands first
+    case "$first_arg" in
+        "check")
+            SSM_OPERATION="check"
+            SSM_CHECK="true"
+            return 0
+            ;;
+        "version")
+            SSM_OPERATION="version"
+            SSM_VERSION="true"
+            return 0
+            ;;
+        "help"|"-h"|"--help")
+            SSM_OPERATION="help"
+            SSM_HELP="true"
+            return 0
+            ;;
+        "install")
+            SSM_OPERATION="install"
+            return 0
+            ;;
+        "exec")
+            if [[ ${#args[@]} -lt 4 ]]; then
+                log_error "Missing required parameters for exec command"
+                log_error "Usage: $(basename "$0") exec <region> <instance-identifier> \"<command>\""
+                return 1
+            fi
+            SSM_OPERATION="exec"
+            SSM_REGION="${args[1]}"
+            SSM_INSTANCE="${args[2]}"
+            SSM_COMMAND="${args[3]}"
+            return 0
+            ;;
+        "exec-tagged")
+            if [[ ${#args[@]} -lt 5 ]]; then
+                log_error "Missing required parameters for exec-tagged command"
+                log_error "Usage: $(basename "$0") exec-tagged <region> <tag-key> <tag-value> \"<command>\""
+                return 1
+            fi
+            SSM_OPERATION="exec-tagged"
+            SSM_REGION="${args[1]}"
+            SSM_TAG_KEY="${args[2]}"
+            SSM_TAG_VALUE="${args[3]}"
+            SSM_COMMAND="${args[4]}"
+            return 0
+            ;;
+        "upload")
+            if [[ ${#args[@]} -lt 5 ]]; then
+                log_error "Missing required parameters for upload command"
+                log_error "Usage: $(basename "$0") upload <region> <instance-identifier> <local-file> <remote-path>"
+                return 1
+            fi
+            SSM_OPERATION="upload"
+            SSM_REGION="${args[1]}"
+            SSM_INSTANCE="${args[2]}"
+            SSM_LOCAL_FILE="${args[3]}"
+            SSM_REMOTE_PATH="${args[4]}"
+            return 0
+            ;;
+        "download")
+            if [[ ${#args[@]} -lt 5 ]]; then
+                log_error "Missing required parameters for download command"
+                log_error "Usage: $(basename "$0") download <region> <instance-identifier> <remote-file> <local-path>"
+                return 1
+            fi
+            SSM_OPERATION="download"
+            SSM_REGION="${args[1]}"
+            SSM_INSTANCE="${args[2]}"
+            SSM_REMOTE_FILE="${args[3]}"
+            SSM_LOCAL_PATH="${args[4]}"
+            return 0
+            ;;
+        *)
+            # Check if it's a region code
+            local test_region
+            if validate_region_code "$first_arg" test_region; then
+                SSM_REGION="$test_region"
+                if [[ ${#args[@]} -eq 1 ]]; then
+                    # Just region - list instances
+                    SSM_OPERATION="list"
+                elif [[ ${#args[@]} -eq 2 ]]; then
+                    # Region and instance - connect
+                    SSM_OPERATION="connect"
+                    SSM_INSTANCE="${args[1]}"
+                else
+                    log_error "Too many arguments for region/instance syntax"
+                    return 1
+                fi
+                return 0
+            else
+                # Assume it's an instance identifier for default region
+                SSM_OPERATION="connect"
+                SSM_REGION="ca-central-1"  # Default region
+                SSM_INSTANCE="$first_arg"
+                return 0
+            fi
+            ;;
+    esac
+}
+
+# Function to parse flag-based parameters
+parse_flag_parameters() {
+    local args=("$@")
+    local i=0
+    
+    while [[ $i -lt ${#args[@]} ]]; do
+        local arg="${args[$i]}"
+        
+        case "$arg" in
+            # Region flags
+            "--region"|"-r")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_REGION="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --region requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # Instance flags
+            "--instance"|"-i")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_INSTANCE="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --instance requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # Command flag
+            "--command"|"-c")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_COMMAND="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --command requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # Tag flags
+            "--tag-key")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_TAG_KEY="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --tag-key requires a value"
+                    return 1
+                fi
+                ;;
+            
+            "--tag-value")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_TAG_VALUE="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --tag-value requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # File path flags
+            "--local-file")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_LOCAL_FILE="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --local-file requires a value"
+                    return 1
+                fi
+                ;;
+            
+            "--remote-file")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_REMOTE_FILE="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --remote-file requires a value"
+                    return 1
+                fi
+                ;;
+            
+            "--local-path")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_LOCAL_PATH="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --local-path requires a value"
+                    return 1
+                fi
+                ;;
+            
+            "--remote-path")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_REMOTE_PATH="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --remote-path requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # Port flags
+            "--local-port")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_LOCAL_PORT="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --local-port requires a value"
+                    return 1
+                fi
+                ;;
+            
+            "--remote-port")
+                if [[ $((i+1)) -lt ${#args[@]} ]]; then
+                    SSM_REMOTE_PORT="${args[$((i+1))]}"
+                    i=$((i+2))
+                else
+                    log_error "Error: --remote-port requires a value"
+                    return 1
+                fi
+                ;;
+            
+            # Operation flags
+            "--exec")
+                SSM_OPERATION="exec"
+                i=$((i+1))
+                ;;
+            
+            "--exec-tagged")
+                SSM_OPERATION="exec-tagged"
+                i=$((i+1))
+                ;;
+            
+            "--upload")
+                SSM_OPERATION="upload"
+                i=$((i+1))
+                ;;
+            
+            "--download")
+                SSM_OPERATION="download"
+                i=$((i+1))
+                ;;
+            
+            "--forward")
+                SSM_OPERATION="forward"
+                i=$((i+1))
+                ;;
+            
+            "--list")
+                SSM_OPERATION="list"
+                i=$((i+1))
+                ;;
+            
+            "--connect")
+                SSM_OPERATION="connect"
+                i=$((i+1))
+                ;;
+            
+            # System flags
+            "--check")
+                SSM_CHECK="true"
+                SSM_OPERATION="check"
+                i=$((i+1))
+                ;;
+            
+            "--help"|"-h")
+                SSM_HELP="true"
+                SSM_OPERATION="help"
+                i=$((i+1))
+                ;;
+            
+            "--version"|"-v")
+                SSM_VERSION="true"
+                SSM_OPERATION="version"
+                i=$((i+1))
+                ;;
+            
+            "--debug")
+                SSM_DEBUG="true"
+                i=$((i+1))
+                ;;
+            
+            # Unknown flag
+            -*)
+                log_error "Error: Unknown flag '$arg'"
+                log_error "Use 'ssm --help' for usage information"
+                return 1
+                ;;
+            
+            # Positional argument (fallback for mixed syntax)
+            *)
+                # If we haven't set a region yet and this looks like a region, use it
+                local test_region
+                if [[ -z "$SSM_REGION" ]] && validate_region_code "$arg" test_region; then
+                    SSM_REGION="$test_region"
+                # If we haven't set an instance yet, treat this as an instance
+                elif [[ -z "$SSM_INSTANCE" ]]; then
+                    SSM_INSTANCE="$arg"
+                # If we haven't set a command yet and this doesn't start with -, treat as command
+                elif [[ -z "$SSM_COMMAND" && ! "$arg" =~ ^- ]]; then
+                    SSM_COMMAND="$arg"
+                else
+                    log_error "Error: Unexpected positional argument '$arg'"
+                    log_error "Use 'ssm --help' for usage information"
+                    return 1
+                fi
+                i=$((i+1))
+                ;;
+        esac
+    done
+    
+    return 0
+}
+
+# Main parameter parsing function
+parse_ssm_parameters() {
+    local args=("$@")
+    
+    # Reset global variables
+    SSM_REGION=""
+    SSM_INSTANCE=""
+    SSM_COMMAND=""
+    SSM_TAG_KEY=""
+    SSM_TAG_VALUE=""
+    SSM_LOCAL_FILE=""
+    SSM_REMOTE_FILE=""
+    SSM_LOCAL_PATH=""
+    SSM_REMOTE_PATH=""
+    SSM_LOCAL_PORT=""
+    SSM_REMOTE_PORT=""
+    SSM_OPERATION=""
+    SSM_HELP="false"
+    SSM_VERSION="false"
+    SSM_CHECK="false"
+    SSM_DEBUG="false"
+    
+    # Check if arguments contain flags
+    if has_flags "${args[@]}"; then
+        # Parse as flag-based parameters
+        if ! parse_flag_parameters "${args[@]}"; then
+            return 1
+        fi
+    else
+        # Parse as positional parameters (backward compatibility)
+        if ! parse_positional_parameters "${args[@]}"; then
+            return 1
+        fi
+    fi
+    
+    # Validate parameter combinations and infer operation if not set
+    if ! validate_and_infer_operation; then
+        return 1
+    fi
+    
+    # Debug output if debug mode is enabled
+    if [[ "$SSM_DEBUG" == "true" ]]; then
+        debug_log "Parsed parameters:"
+        debug_log "  Region: '$SSM_REGION'"
+        debug_log "  Instance: '$SSM_INSTANCE'"
+        debug_log "  Command: '$SSM_COMMAND'"
+        debug_log "  Tag Key: '$SSM_TAG_KEY'"
+        debug_log "  Tag Value: '$SSM_TAG_VALUE'"
+        debug_log "  Local File: '$SSM_LOCAL_FILE'"
+        debug_log "  Remote File: '$SSM_REMOTE_FILE'"
+        debug_log "  Local Path: '$SSM_LOCAL_PATH'"
+        debug_log "  Remote Path: '$SSM_REMOTE_PATH'"
+        debug_log "  Local Port: '$SSM_LOCAL_PORT'"
+        debug_log "  Remote Port: '$SSM_REMOTE_PORT'"
+        debug_log "  Operation: '$SSM_OPERATION'"
+        debug_log "  Help: '$SSM_HELP'"
+        debug_log "  Version: '$SSM_VERSION'"
+        debug_log "  Check: '$SSM_CHECK'"
+        debug_log "  Debug: '$SSM_DEBUG'"
+    fi
+    
+    return 0
+}
+
+# Function to validate parameter combinations and infer operation
+validate_and_infer_operation() {
+    # If no operation is set, try to infer it
+    if [[ -z "$SSM_OPERATION" ]]; then
+        # Infer operation based on parameters
+        if [[ -n "$SSM_COMMAND" && -n "$SSM_TAG_KEY" && -n "$SSM_TAG_VALUE" ]]; then
+            SSM_OPERATION="exec-tagged"
+        elif [[ -n "$SSM_COMMAND" ]]; then
+            SSM_OPERATION="exec"
+        elif [[ -n "$SSM_LOCAL_FILE" && -n "$SSM_REMOTE_PATH" ]]; then
+            SSM_OPERATION="upload"
+        elif [[ -n "$SSM_REMOTE_FILE" && -n "$SSM_LOCAL_PATH" ]]; then
+            SSM_OPERATION="download"
+        elif [[ -n "$SSM_LOCAL_PORT" && -n "$SSM_REMOTE_PORT" ]]; then
+            SSM_OPERATION="forward"
+        elif [[ -n "$SSM_INSTANCE" ]]; then
+            SSM_OPERATION="connect"
+        elif [[ -n "$SSM_REGION" ]]; then
+            SSM_OPERATION="list"
+        fi
+    fi
+    
+    # Validate region if specified
+    if [[ -n "$SSM_REGION" ]]; then
+        # Check if it's already a full region name (e.g., "us-east-1")
+        if [[ "$SSM_REGION" =~ ^[a-z]+-[a-z]+-[0-9]+$ ]]; then
+            # Already a full region name, no need to validate
+            :
+        else
+            # It's a region code, validate and convert
+            local validated_region
+            if ! validate_region_code "$SSM_REGION" validated_region; then
+                log_error "Error: Invalid region '$SSM_REGION'"
+                return 1
+            fi
+            # Update SSM_REGION with the validated full region name
+            SSM_REGION="$validated_region"
+        fi
+    fi
+    
+    # Set default region if not specified and operation requires it
+    if [[ -z "$SSM_REGION" && "$SSM_OPERATION" =~ ^(connect|exec|exec-tagged|upload|download|forward|list)$ ]]; then
+        SSM_REGION="ca-central-1"  # Default region
+    fi
+    
+    # Validate required parameters for each operation
+    case "$SSM_OPERATION" in
+        "exec")
+            if [[ -z "$SSM_INSTANCE" ]]; then
+                log_error "Error: --instance is required for exec operation"
+                return 1
+            fi
+            if [[ -z "$SSM_COMMAND" ]]; then
+                log_error "Error: --command is required for exec operation"
+                return 1
+            fi
+            ;;
+        "exec-tagged")
+            if [[ -z "$SSM_TAG_KEY" ]]; then
+                log_error "Error: --tag-key is required for exec-tagged operation"
+                return 1
+            fi
+            if [[ -z "$SSM_TAG_VALUE" ]]; then
+                log_error "Error: --tag-value is required for exec-tagged operation"
+                return 1
+            fi
+            if [[ -z "$SSM_COMMAND" ]]; then
+                log_error "Error: --command is required for exec-tagged operation"
+                return 1
+            fi
+            ;;
+        "upload")
+            if [[ -z "$SSM_INSTANCE" ]]; then
+                log_error "Error: --instance is required for upload operation"
+                return 1
+            fi
+            if [[ -z "$SSM_LOCAL_FILE" ]]; then
+                log_error "Error: --local-file is required for upload operation"
+                return 1
+            fi
+            if [[ -z "$SSM_REMOTE_PATH" ]]; then
+                log_error "Error: --remote-path is required for upload operation"
+                return 1
+            fi
+            ;;
+        "download")
+            if [[ -z "$SSM_INSTANCE" ]]; then
+                log_error "Error: --instance is required for download operation"
+                return 1
+            fi
+            if [[ -z "$SSM_REMOTE_FILE" ]]; then
+                log_error "Error: --remote-file is required for download operation"
+                return 1
+            fi
+            if [[ -z "$SSM_LOCAL_PATH" ]]; then
+                log_error "Error: --local-path is required for download operation"
+                return 1
+            fi
+            ;;
+        "forward")
+            if [[ -z "$SSM_INSTANCE" ]]; then
+                log_error "Error: --instance is required for forward operation"
+                return 1
+            fi
+            if [[ -z "$SSM_LOCAL_PORT" ]]; then
+                log_error "Error: --local-port is required for forward operation"
+                return 1
+            fi
+            if [[ -z "$SSM_REMOTE_PORT" ]]; then
+                log_error "Error: --remote-port is required for forward operation"
+                return 1
+            fi
+            ;;
+        "connect")
+            if [[ -z "$SSM_INSTANCE" ]]; then
+                log_error "Error: --instance is required for connect operation"
+                return 1
+            fi
+            ;;
+    esac
+    
+    return 0
+}
+
+# Function to get parsed parameters (for use in main script)
+get_ssm_region() {
+    echo "$SSM_REGION"
+}
+
+get_ssm_instance() {
+    echo "$SSM_INSTANCE"
+}
+
+get_ssm_command() {
+    echo "$SSM_COMMAND"
+}
+
+get_ssm_tag_key() {
+    echo "$SSM_TAG_KEY"
+}
+
+get_ssm_tag_value() {
+    echo "$SSM_TAG_VALUE"
+}
+
+get_ssm_local_file() {
+    echo "$SSM_LOCAL_FILE"
+}
+
+get_ssm_remote_file() {
+    echo "$SSM_REMOTE_FILE"
+}
+
+get_ssm_local_path() {
+    echo "$SSM_LOCAL_PATH"
+}
+
+get_ssm_remote_path() {
+    echo "$SSM_REMOTE_PATH"
+}
+
+get_ssm_local_port() {
+    echo "$SSM_LOCAL_PORT"
+}
+
+get_ssm_remote_port() {
+    echo "$SSM_REMOTE_PORT"
+}
+
+get_ssm_operation() {
+    echo "$SSM_OPERATION"
+}
+
+get_ssm_help() {
+    echo "$SSM_HELP"
+}
+
+get_ssm_version() {
+    echo "$SSM_VERSION"
+}
+
+get_ssm_check() {
+    echo "$SSM_CHECK"
+}
+
+get_ssm_debug() {
+    echo "$SSM_DEBUG"
+}
+
+# Function to check if a specific flag is set
+is_ssm_flag_set() {
+    local flag="$1"
+    case "$flag" in
+        "help") [[ "$SSM_HELP" == "true" ]] && return 0 ;;
+        "version") [[ "$SSM_VERSION" == "true" ]] && return 0 ;;
+        "check") [[ "$SSM_CHECK" == "true" ]] && return 0 ;;
+        "debug") [[ "$SSM_DEBUG" == "true" ]] && return 0 ;;
+        *) return 1 ;;
+    esac
+    return 1
+}

--- a/ssm
+++ b/ssm
@@ -319,15 +319,9 @@ handle_exec_command() {
         exit 1
     fi
 
-    local region_code="$1"
+    local region="$1"  # Already validated and translated by parameter parser
     local instance_identifier="$2"
     local command="$3"
-
-    local region
-    if ! validate_region_code "$region_code" region; then
-        log_error "Invalid region code: $region_code"
-        exit 1
-    fi
 
     if ! validate_instance_identifier "$instance_identifier"; then
         exit 1
@@ -353,16 +347,10 @@ handle_exec_tagged_command() {
         exit 1
     fi
 
-    local region_code="$1"
+    local region="$1"  # Already validated and translated by parameter parser
     local tag_key="$2"
     local tag_value="$3"
     local command="$4"
-
-    local region
-    if ! validate_region_code "$region_code" region; then
-        log_error "Invalid region code: $region_code"
-        exit 1
-    fi
 
     log_info "Executing command on instances with tag $tag_key=$tag_value in region $region"
     
@@ -384,16 +372,10 @@ handle_upload_command() {
         exit 1
     fi
 
-    local region_code="$1"
+    local region="$1"  # Already validated and translated by parameter parser
     local instance_identifier="$2"
     local local_file="$3"
     local remote_path="$4"
-
-    local region
-    if ! validate_region_code "$region_code" region; then
-        log_error "Invalid region code: $region_code"
-        exit 1
-    fi
 
     if ! validate_instance_identifier "$instance_identifier"; then
         exit 1
@@ -420,16 +402,10 @@ handle_download_command() {
         exit 1
     fi
 
-    local region_code="$1"
+    local region="$1"  # Already validated and translated by parameter parser
     local instance_identifier="$2"
     local remote_file="$3"
     local local_path="$4"
-
-    local region
-    if ! validate_region_code "$region_code" region; then
-        log_error "Invalid region code: $region_code"
-        exit 1
-    fi
 
     if ! validate_instance_identifier "$instance_identifier"; then
         exit 1

--- a/ssm
+++ b/ssm
@@ -68,6 +68,19 @@ else
     log_warn "File transfer module not found. Upload/download commands will not be available."
 fi
 
+# Import parameter parser module
+if [ -f "${SCRIPT_DIR}/src/07_ssm_parameter_parser.sh" ]; then
+    # shellcheck source=./src/07_ssm_parameter_parser.sh
+    source "${SCRIPT_DIR}/src/07_ssm_parameter_parser.sh"
+elif [ -f "/usr/local/bin/src/07_ssm_parameter_parser.sh" ]; then
+    # shellcheck source=/dev/null
+    source "/usr/local/bin/src/07_ssm_parameter_parser.sh"
+else
+    echo "[ERROR] src/07_ssm_parameter_parser.sh not found. This script requires the parameter parser module." >&2
+    echo "Please ensure src/07_ssm_parameter_parser.sh is present in the script directory or in /usr/local/bin/src/." >&2
+    exit 1
+fi
+
 # Source version module
 if [ -f "${SCRIPT_DIR}/src/00_version.sh" ]; then
     # shellcheck source=./src/00_version.sh
@@ -84,12 +97,24 @@ fi
 usage() {
     cat << EOF
 AWS SSM Session Manager Helper
-Usage: $(basename "$0") [region] [instance-id]
-       $(basename "$0") [instance-id]        # Uses default region (Canada Central)
+
+POSITIONAL SYNTAX (current - backward compatible):
+  $(basename "$0") [region] [instance-id]    # Connect to instance
+  $(basename "$0") [instance-id]             # Uses default region (Canada Central)
+  $(basename "$0") [region]                  # List instances in region
+
+FLAG-BASED SYNTAX (new - enterprise friendly):
+  $(basename "$0") --region [region] --instance [instance]  # Connect to instance
+  $(basename "$0") --region [region] --list                # List instances
+  $(basename "$0") --region [region]                       # List instances
+
+MIXED SYNTAX (also supported):
+  $(basename "$0") cac1 --instance i-1234567890abcd        # Mixed positional/flag
+  $(basename "$0") --region cac1 i-1234567890abcd          # Mixed flag/positional
 
 Supported regions:
   cac1  - Canada Central (Montreal) [default]
-  apse1 -  Asia Pacific (Seoul)
+  apse1 - Asia Pacific (Seoul)
   caw1  - Canada West (Calgary)
   usw1  - US West (N. California)
   use1  - US East (N. Virginia)
@@ -128,13 +153,23 @@ EOF
 
     cat << EOF
 
-Examples:
+POSITIONAL EXAMPLES (current syntax):
   $(basename "$0") cac1                             # List instances in Canada Central
   $(basename "$0") use1 i-1234                      # Connect to instance in US East
   $(basename "$0") i-1234                           # Connect to instance in Canada Central
   $(basename "$0") exec cac1 i-1234 "systemctl status nginx"   # Run command on instance
   $(basename "$0") exec cac1 web-server-prod "systemctl status nginx"  # Run command using instance name
   $(basename "$0") exec-tagged use1 Role web "df -h" # Run command on instances with tag Role=web
+
+FLAG-BASED EXAMPLES (new syntax):
+  $(basename "$0") --region cac1 --list            # List instances in Canada Central
+  $(basename "$0") --region use1 --instance i-1234 --connect  # Connect to instance
+  $(basename "$0") --exec --region cac1 --instance i-1234 --command "systemctl status nginx"  # Run command
+  $(basename "$0") --exec-tagged --region use1 --tag-key Role --tag-value web --command "df -h"  # Run on tagged instances
+
+MIXED EXAMPLES (combined syntax):
+  $(basename "$0") cac1 --instance i-1234          # Region positional, instance flag
+  $(basename "$0") --region use1 i-1234            # Region flag, instance positional
 EOF
 
     if [ "$FILE_TRANSFER_AVAILABLE" = true ]; then
@@ -410,64 +445,58 @@ handle_download_command() {
 
 # Main logic
 main() {
-    # Handle special commands first
-    case "${1:-}" in
-        "version")
-            show_version
-            exit 0
-            ;;
-        "install")
-            # Since we have interactive SSM plugin installation, just show AWS CLI instructions
-            log_info "Installation Instructions:"
-            echo
-            log_info "1. AWS CLI Installation:"
-            echo "   Visit: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
-            echo "   Follow the instructions for your platform"
-            echo
-            log_info "2. Session Manager Plugin:"
-            echo "   Run '$(basename "$0") check' to install the plugin interactively"
-            echo "   Or visit: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
-            if [ "$FILE_TRANSFER_AVAILABLE" = true ]; then
-                echo
-                log_info "3. File Transfer Requirements:"
-                echo "   - For large files (≥1MB): Instances need AWS CLI and S3 access"
-                echo "   - For small files (<1MB): No additional requirements"
-            fi
-            exit 0
-            ;;
-        "check")
-            check_requirements
-            exit 0
-            ;;
-        "help"|"-h"|"--help")
-            usage
-            exit 0
-            ;;
-        "exec")
-            shift
-            handle_exec_command "$@"
-            exit $?
-            ;;
-        "exec-tagged")
-            shift
-            handle_exec_tagged_command "$@"
-            exit $?
-            ;;
-        "upload")
-            shift
-            handle_upload_command "$@"
-            exit $?
-            ;;
-        "download")
-            shift
-            handle_download_command "$@"
-            exit $?
-            ;;
-    esac
+    # Parse parameters using the new parameter parser
+    if ! parse_ssm_parameters "$@"; then
+        exit 1
+    fi
 
-    # Regular command processing - check for no arguments first
-    if [ $# -eq 0 ]; then
+    # Handle commands based on parsed parameters
+    local operation="$(get_ssm_operation)"
+    local region="$(get_ssm_region)"
+    local instance="$(get_ssm_instance)"
+    local command="$(get_ssm_command)"
+    local tag_key="$(get_ssm_tag_key)"
+    local tag_value="$(get_ssm_tag_value)"
+    local local_file="$(get_ssm_local_file)"
+    local remote_file="$(get_ssm_remote_file)"
+    local local_path="$(get_ssm_local_path)"
+    local remote_path="$(get_ssm_remote_path)"
+    local local_port="$(get_ssm_local_port)"
+    local remote_port="$(get_ssm_remote_port)"
+
+    # Handle system commands first
+    if [[ "$(get_ssm_help)" == "true" ]]; then
         usage
+        exit 0
+    fi
+
+    if [[ "$(get_ssm_version)" == "true" ]]; then
+        show_version
+        exit 0
+    fi
+
+    if [[ "$(get_ssm_check)" == "true" ]]; then
+        check_requirements
+        exit 0
+    fi
+
+    if [[ "$operation" == "install" ]]; then
+        # Since we have interactive SSM plugin installation, just show AWS CLI instructions
+        log_info "Installation Instructions:"
+        echo
+        log_info "1. AWS CLI Installation:"
+        echo "   Visit: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+        echo "   Follow the instructions for your platform"
+        echo
+        log_info "2. Session Manager Plugin:"
+        echo "   Run '$(basename "$0") check' to install the plugin interactively"
+        echo "   Or visit: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html"
+        if [ "$FILE_TRANSFER_AVAILABLE" = true ]; then
+            echo
+            log_info "3. File Transfer Requirements:"
+            echo "   - For large files (≥1MB): Instances need AWS CLI and S3 access"
+            echo "   - For small files (<1MB): No additional requirements"
+        fi
         exit 0
     fi
 
@@ -477,15 +506,11 @@ main() {
         exit 1
     fi
 
-    # Process commands that require system requirements
-    if [ $# -eq 1 ]; then
-        if [[ "$1" =~ ^(apse1|cac1|caw1|usw1|use1|euw1)$ ]]; then
-            if ! validate_region_code "$1" REGION; then
-                log_error "Invalid region code: $1"
-                exit 1
-            fi
-            log_info "Listing instances in $REGION..."
-            aws ec2 describe-instances --region "$REGION" \
+    # Execute operations based on parsed parameters
+    case "$operation" in
+        "list")
+            log_info "Listing instances in $region..."
+            aws ec2 describe-instances --region "$region" \
                 --query "Reservations[*].Instances[*].{
                     Name: Tags[?Key=='Name'].Value | [0],
                     InstanceId: InstanceId,
@@ -494,53 +519,72 @@ main() {
                     OS: PlatformDetails
                 }" \
                 --output table
-            echo -e "\nUsage: $(basename "$0") $1 <instance-id>"
-        else
-            if ! validate_instance_identifier "$1"; then
+            echo -e "\nUsage: $(basename "$0") $region <instance-id>"
+            ;;
+        "connect")
+            if ! validate_instance_identifier "$instance"; then
                 exit 1
             fi
             
             # Resolve instance name to ID if needed
-            local instance_id="$1"
-            if ! [[ "$1" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
-                instance_id=$(resolve_instance_identifier "$1" "$REGION")
+            local instance_id="$instance"
+            if ! [[ "$instance" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+                instance_id=$(resolve_instance_identifier "$instance" "$region")
                 if ! [[ "$instance_id" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
                     exit 1
                 fi
             fi
             
-            log_info "Connecting to instance $instance_id in $REGION..."
+            log_info "Connecting to instance $instance_id in $region..."
             aws ssm start-session \
-                --region "$REGION" \
+                --region "$region" \
                 --target "$instance_id"
-        fi
-elif [ $# -eq 2 ]; then
-    if ! validate_region_code "$1" REGION; then
-        log_error "Invalid region. Use cac1, caw1, usw1, use1, or euw1"
-        usage
-        exit 1
-    fi
-    if ! validate_instance_identifier "$2"; then
-        exit 1
-    fi
-    
-    # Resolve instance name to ID if needed
-    local instance_id="$2"
-    if ! [[ "$2" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
-    instance_id=$(resolve_instance_identifier "$2" "$REGION")
-    if ! [[ "$instance_id" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
-        exit 1
-    fi
-fi
-
-    log_info "Connecting to instance $instance_id in $REGION..."
-    aws ssm start-session \
-        --region "$REGION" \
-        --target "$instance_id"
-else
-    usage
-    exit 1
-fi
+            ;;
+        "exec")
+            handle_exec_command "$region" "$instance" "$command"
+            exit $?
+            ;;
+        "exec-tagged")
+            handle_exec_tagged_command "$region" "$tag_key" "$tag_value" "$command"
+            exit $?
+            ;;
+        "upload")
+            if [ "$FILE_TRANSFER_AVAILABLE" != true ]; then
+                log_error "File transfer module not available"
+                log_error "Please ensure src/04_ssm_file_transfer.sh is present and properly sourced"
+                exit 1
+            fi
+            handle_upload_command "$region" "$instance" "$local_file" "$remote_path"
+            exit $?
+            ;;
+        "download")
+            if [ "$FILE_TRANSFER_AVAILABLE" != true ]; then
+                log_error "File transfer module not available"
+                log_error "Please ensure src/04_ssm_file_transfer.sh is present and properly sourced"
+                exit 1
+            fi
+            handle_download_command "$region" "$instance" "$remote_file" "$local_path"
+            exit $?
+            ;;
+        "forward")
+            log_info "Setting up port forwarding: localhost:$local_port -> $instance:$remote_port"
+            aws ssm start-session \
+                --region "$region" \
+                --target "$instance" \
+                --document-name "AWS-StartPortForwardingSession" \
+                --parameters "portNumber=$remote_port,localPortNumber=$local_port"
+            ;;
+        "")
+            # No operation determined, show usage
+            usage
+            exit 0
+            ;;
+        *)
+            log_error "Unknown operation: $operation"
+            usage
+            exit 1
+            ;;
+    esac
 }
 
 # Run main function

--- a/ssm
+++ b/ssm
@@ -77,7 +77,8 @@ elif [ -f "/usr/local/bin/src/07_ssm_parameter_parser.sh" ]; then
     source "/usr/local/bin/src/07_ssm_parameter_parser.sh"
 else
     echo "[ERROR] src/07_ssm_parameter_parser.sh not found. This script requires the parameter parser module." >&2
-    echo "Please ensure src/07_ssm_parameter_parser.sh is present in the script directory or in /usr/local/bin/src/." >&2
+    echo "Remediation: Please ensure src/07_ssm_parameter_parser.sh is present in the script directory or in /usr/local/bin/src/." >&2
+    echo "You may need to run 'make install' or consult the installation instructions in the README to properly set up the required modules." >&2
     exit 1
 fi
 
@@ -555,10 +556,19 @@ main() {
             exit $?
             ;;
         "forward")
-            log_info "Setting up port forwarding: localhost:$local_port -> $instance:$remote_port"
+            # Resolve instance identifier to instance ID if necessary
+            local instance_id="$instance"
+            if ! [[ "$instance" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+                instance_id=$(resolve_instance_identifier "$instance" "$region")
+                if ! [[ "$instance_id" =~ ^i-[a-zA-Z0-9]{8,}$ ]]; then
+                    exit 1
+                fi
+            fi
+            
+            log_info "Setting up port forwarding: localhost:$local_port -> $instance_id:$remote_port"
             aws ssm start-session \
                 --region "$region" \
-                --target "$instance" \
+                --target "$instance_id" \
                 --document-name "AWS-StartPortForwardingSession" \
                 --parameters "portNumber=$remote_port,localPortNumber=$local_port"
             ;;

--- a/ssm
+++ b/ssm
@@ -38,6 +38,8 @@ else
     exit 1
 fi
 
+
+
 # Import run_command functions
 if [ -f "${SCRIPT_DIR}/src/03_ssm_command_runner.sh" ]; then
     # shellcheck source=./src/03_ssm_command_runner.sh

--- a/ssm
+++ b/ssm
@@ -292,8 +292,7 @@ install_ssm_plugin() {
     fi
 }
 
-# Default region
-REGION="ca-central-1"
+# Default region is now handled by the parameter parser
 
 # Validate instance ID format
 validate_instance_identifier() {
@@ -451,18 +450,31 @@ main() {
     fi
 
     # Handle commands based on parsed parameters
-    local operation="$(get_ssm_operation)"
-    local region="$(get_ssm_region)"
-    local instance="$(get_ssm_instance)"
-    local command="$(get_ssm_command)"
-    local tag_key="$(get_ssm_tag_key)"
-    local tag_value="$(get_ssm_tag_value)"
-    local local_file="$(get_ssm_local_file)"
-    local remote_file="$(get_ssm_remote_file)"
-    local local_path="$(get_ssm_local_path)"
-    local remote_path="$(get_ssm_remote_path)"
-    local local_port="$(get_ssm_local_port)"
-    local remote_port="$(get_ssm_remote_port)"
+    local operation
+    local region
+    local instance
+    local command
+    local tag_key
+    local tag_value
+    local local_file
+    local remote_file
+    local local_path
+    local remote_path
+    local local_port
+    local remote_port
+    
+    operation="$(get_ssm_operation)"
+    region="$(get_ssm_region)"
+    instance="$(get_ssm_instance)"
+    command="$(get_ssm_command)"
+    tag_key="$(get_ssm_tag_key)"
+    tag_value="$(get_ssm_tag_value)"
+    local_file="$(get_ssm_local_file)"
+    remote_file="$(get_ssm_remote_file)"
+    local_path="$(get_ssm_local_path)"
+    remote_path="$(get_ssm_remote_path)"
+    local_port="$(get_ssm_local_port)"
+    remote_port="$(get_ssm_remote_port)"
 
     # Handle system commands first
     if [[ "$(get_ssm_help)" == "true" ]]; then

--- a/tests/QA_SSM_TESTS.md
+++ b/tests/QA_SSM_TESTS.md
@@ -9,6 +9,20 @@ This document outlines the comprehensive test suite for the new flag-based param
 **Version**: 1.0.0  
 **Status**: Ready for Testing
 
+## Command Usage Context
+
+**Development Testing** (used in this QA suite):
+```bash
+./ssm --help    # Tests local development version
+```
+
+**Production Usage** (after `make install`):
+```bash
+ssm --help      # Uses globally installed version
+```
+
+This QA document uses `./ssm` to test the local development version before installation.
+
 ## Test Environment Requirements
 
 ### Prerequisites

--- a/tests/QA_SSM_TESTS.md
+++ b/tests/QA_SSM_TESTS.md
@@ -36,13 +36,13 @@ This QA document uses `./ssm` to test the local development version before insta
 ### Test Data Setup
 ```bash
 # Ensure test instances are available
-# ⚠️  WARNING: Replace with your actual instance IDs and region
+# ⚠️  WARNING: Replace placeholder values with your actual AWS resources
 # Do not commit real instance IDs to version control
-export TEST_REGION="us-east-1"
-export TEST_INSTANCE_1="i-1234567890abcdef0"
-export TEST_INSTANCE_2="i-0987654321fedcba0"
-export TEST_TAG_KEY="Environment"
-export TEST_TAG_VALUE="test"
+export TEST_REGION="<YOUR_AWS_REGION>"              # e.g., "us-east-1", "ca-central-1"
+export TEST_INSTANCE_1="<YOUR_INSTANCE_ID_1>"       # e.g., "i-1234567890abcdef0"
+export TEST_INSTANCE_2="<YOUR_INSTANCE_ID_2>"       # e.g., "i-0987654321fedcba0"  
+export TEST_TAG_KEY="<YOUR_TAG_KEY>"                # e.g., "Environment"
+export TEST_TAG_VALUE="<YOUR_TAG_VALUE>"            # e.g., "test"
 
 # Create test files for upload/download testing
 echo "Test content for upload" > test-upload.txt

--- a/tests/QA_SSM_TESTS.md
+++ b/tests/QA_SSM_TESTS.md
@@ -1,254 +1,509 @@
-# QA Test Scenarios
+# SSM Flag-Based Parameters QA Test Suite
 
-**Prerequisites:** AWS CLI configured, EC2 instances in ca-central-1, SSM agent installed on instances.
+## Overview
 
-**File Transfer Prerequisites (NEW):** 
-- For large files (≥1MB): Target instances must have AWS CLI installed and proper IAM permissions for S3 access
-- For small files (<1MB): No additional requirements beyond SSM
-- S3 bucket will be auto-created in the same region as the target instance
+This document outlines the comprehensive test suite for the new flag-based parameter support in the `ssm` tool. The feature adds support for both positional and flag-based syntax while maintaining full backward compatibility.
 
-**Setup:** Navigate to your local ztiaws directory, switch to the feature branch, use `./ssm` for all commands below.
+**Feature**: Support both positional and flag-based parameters for improved UX and scalability  
+**Module**: `src/07_ssm_parameter_parser.sh`  
+**Version**: 1.0.0  
+**Status**: Ready for Testing
 
-Replace `i-1234567890abcdef0` with real instance ID and `web-server` with real instance name.
+## Test Environment Requirements
 
-**Testing other regions:** Replace `cac1` with `use1`, `usw2`, etc. **Testing multiple instances:** Use different instance names/IDs in same region.
+### Prerequisites
+- AWS CLI v2.x installed and configured
+- AWS Session Manager plugin installed
+- `jq` dependency installed (for some operations)
+- Valid AWS credentials configured
+- Test EC2 instances with SSM agent enabled
+- Proper IAM permissions for SSM Session Manager
 
-## Basic Commands
+### Test Data Setup
 ```bash
-./ssm help                     # Shows help
-./ssm version                  # Shows version
-./ssm check                    # Verifies requirements
+# Ensure test instances are available
+# ⚠️  WARNING: Replace with your actual instance IDs and region
+# Do not commit real instance IDs to version control
+export TEST_REGION="us-east-1"
+export TEST_INSTANCE_1="i-1234567890abcdef0"
+export TEST_INSTANCE_2="i-0987654321fedcba0"
+export TEST_TAG_KEY="Environment"
+export TEST_TAG_VALUE="test"
+
+# Create test files for upload/download testing
+echo "Test content for upload" > test-upload.txt
+mkdir -p test-downloads
 ```
 
-## Instance Listing
+## Test Categories
+
+### 1. Backward Compatibility Tests
+
+#### Test 1.1: Positional Parameter Support
+**Objective**: Verify existing positional syntax continues to work
+
+**Test Cases**:
 ```bash
-./ssm cac1                     # Lists instances
-./ssm xyz1                     # Invalid region error
+# Test 1.1.1: No arguments (show help)
+./ssm
+Expected: Shows help message
+
+# Test 1.1.2: Single region argument (list instances)
+./ssm $TEST_REGION
+Expected: Lists instances in test region
+
+# Test 1.1.3: Instance only (connect with default region)
+./ssm $TEST_INSTANCE_1
+Expected: Connects to instance in default region (ca-central-1)
+
+# Test 1.1.4: Region and instance (connect)
+./ssm $TEST_REGION $TEST_INSTANCE_1
+Expected: Connects to instance in specified region
+
+# Test 1.1.5: System commands
+./ssm check
+./ssm version
+./ssm help
+Expected: All commands work as before
+
+# Test 1.1.6: Exec command
+./ssm exec $TEST_REGION $TEST_INSTANCE_1 "uptime"
+Expected: Executes command on instance
+
+# Test 1.1.7: Exec-tagged command
+./ssm exec-tagged $TEST_REGION $TEST_TAG_KEY $TEST_TAG_VALUE "hostname"
+Expected: Executes command on tagged instances
+
+# Test 1.1.8: Upload command (if available)
+./ssm upload $TEST_REGION $TEST_INSTANCE_1 test-upload.txt /tmp/test-upload.txt
+Expected: Uploads file to instance
+
+# Test 1.1.9: Download command (if available)
+./ssm download $TEST_REGION $TEST_INSTANCE_1 /tmp/test-upload.txt ./test-downloads/downloaded.txt
+Expected: Downloads file from instance
 ```
 
-## Connect to Instance
-```bash
-# Using Instance ID
-./ssm cac1 i-1234567890abcdef0 # Connects via SSM
-./ssm cac1 i-123               # Invalid ID error
+**Pass Criteria**: All existing positional commands work exactly as before
 
-# Using Instance Name (NEW)
-./ssm cac1 web-server          # Resolves name and connects
-./ssm cac1 fake-name           # Instance not found error
+#### Test 1.2: Existing Functionality Preservation
+**Objective**: Ensure all existing features work with new parser
+
+**Test Cases**:
+```bash
+# Test 1.2.1: Help variations
+./ssm help
+./ssm -h
+./ssm --help
+Expected: All show help message
+
+# Test 1.2.2: Version command
+./ssm version
+Expected: Shows version information
+
+# Test 1.2.3: Check command
+./ssm check
+Expected: Validates system requirements
+
+# Test 1.2.4: Install command
+./ssm install
+Expected: Shows installation instructions
 ```
 
-## Execute Commands
-```bash
-# Using Instance ID
-./ssm exec cac1 i-1234567890abcdef0 'hostname'  # Runs command
-./ssm exec cac1 i-123 'ls'                      # Invalid ID error
+### 2. Flag-Based Parameter Tests
 
-# Using Instance Name (NEW)
-./ssm exec cac1 web-server 'hostname'           # Resolves and runs command
-./ssm exec cac1 fake-name 'ls'                  # Instance not found
+#### Test 2.1: Basic Flag Support
+**Objective**: Verify new flag-based syntax works correctly
+
+**Test Cases**:
+```bash
+# Test 2.1.1: List with region flag
+./ssm --region $TEST_REGION --list
+Expected: Lists instances in test region
+
+# Test 2.1.2: Connect with flags
+./ssm --region $TEST_REGION --instance $TEST_INSTANCE_1 --connect
+Expected: Connects to instance
+
+# Test 2.1.3: Short flags
+./ssm -r $TEST_REGION --list
+./ssm --region $TEST_REGION -i $TEST_INSTANCE_1
+Expected: Short flags work correctly
+
+# Test 2.1.4: Help flags
+./ssm --help
+./ssm -h
+Expected: Shows help
+
+# Test 2.1.5: Version flags
+./ssm --version
+./ssm -v
+Expected: Shows version
+
+# Test 2.1.6: Check flag
+./ssm --check
+Expected: Runs system requirements check
 ```
 
-## Tagged Execution
+#### Test 2.2: Operation Flags
+**Objective**: Test operation-specific flags
+
+**Test Cases**:
 ```bash
-./ssm exec-tagged cac1 Environment prod 'hostname'  # Runs on tagged instances
-./ssm exec-tagged cac1 Role                         # Missing parameters
+# Test 2.2.1: Exec operation
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "uptime"
+Expected: Executes command on instance
+
+# Test 2.2.2: Exec-tagged operation
+./ssm --exec-tagged --region $TEST_REGION --tag-key $TEST_TAG_KEY --tag-value $TEST_TAG_VALUE --command "hostname"
+Expected: Executes command on tagged instances
+
+# Test 2.2.3: Upload operation (if available)
+./ssm --upload --region $TEST_REGION --instance $TEST_INSTANCE_1 --local-file test-upload.txt --remote-path /tmp/test-flag-upload.txt
+Expected: Uploads file to instance
+
+# Test 2.2.4: Download operation (if available)
+./ssm --download --region $TEST_REGION --instance $TEST_INSTANCE_1 --remote-file /tmp/test-flag-upload.txt --local-path ./test-downloads/flag-downloaded.txt
+Expected: Downloads file from instance
+
+# Test 2.2.5: Debug flag
+./ssm --debug --region $TEST_REGION --list
+Expected: Shows debug information during execution
 ```
 
-## File Transfer (NEW)
+#### Test 2.3: Advanced Operations
+**Objective**: Test advanced flag functionality
+
+**Test Cases**:
 ```bash
-# Small file upload (< 1MB - uses direct SSM transfer)
-echo "Hello World" > test_small.txt
-./ssm upload cac1 i-1234567890abcdef0 test_small.txt /tmp/test_small.txt
-./ssm upload cac1 web-server test_small.txt /tmp/test_small_name.txt
+# Test 2.3.1: Port forwarding (if supported)
+./ssm --forward --region $TEST_REGION --instance $TEST_INSTANCE_1 --local-port 8080 --remote-port 80
+Expected: Sets up port forwarding (cancel after verification)
 
-# Small file download (< 1MB - uses direct SSM transfer)
-./ssm download cac1 i-1234567890abcdef0 /tmp/test_small.txt ./downloaded_small.txt
-./ssm download cac1 web-server /tmp/test_small_name.txt ./downloaded_small_name.txt
+# Test 2.3.2: Region code validation
+./ssm --region invalid-region --list
+Expected: Error message about invalid region
 
-# Large file upload (≥ 1MB - uses S3 intermediary)
-dd if=/dev/zero of=test_large.txt bs=1M count=2  # Creates 2MB file
-./ssm upload cac1 i-1234567890abcdef0 test_large.txt /tmp/test_large.txt
-./ssm upload cac1 web-server test_large.txt /tmp/test_large_name.txt
-
-# Large file download (≥ 1MB - uses S3 intermediary)
-./ssm download cac1 i-1234567890abcdef0 /tmp/test_large.txt ./downloaded_large.txt
-./ssm download cac1 web-server /tmp/test_large_name.txt ./downloaded_large_name.txt
-
-# File transfer to nested directories
-./ssm upload cac1 i-1234567890abcdef0 test_small.txt /opt/app/config/settings.txt
-./ssm download cac1 i-1234567890abcdef0 /var/log/application.log ./logs/app.log
-
-# File transfer error cases
-./ssm upload cac1 i-1234567890abcdef0 nonexistent.txt /tmp/test.txt        # File not found
-./ssm upload cac1 fake-name test_small.txt /tmp/test.txt                   # Instance not found
-./ssm download cac1 i-1234567890abcdef0 /nonexistent/file.txt ./test.txt   # Remote file not found
-./ssm download cac1 fake-name /tmp/test.txt ./test.txt                     # Instance not found
-
-# File transfer parameter validation
-./ssm upload cac1                                      # Missing parameters
-./ssm upload cac1 i-1234567890abcdef0                  # Missing file paths
-./ssm download cac1                                    # Missing parameters
-./ssm download cac1 i-1234567890abcdef0                # Missing file paths
-
-# IAM error handling (basic validation)
-./ssm upload cac1 instance-without-iam test_small.txt /tmp/test.txt        # Should fail with clear IAM error
+# Test 2.3.3: Complex command with multiple flags
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "ps aux | grep ssh" --debug
+Expected: Executes complex command with debug output
 ```
 
-## Error Cases
+### 3. Mixed Syntax Tests
+
+#### Test 3.1: Positional + Flag Combinations
+**Objective**: Test mixed syntax scenarios
+
+**Test Cases**:
 ```bash
-./ssm invalid-command                    # Shows help
-./ssm exec cac1                          # Missing parameters
-./ssm exec cac1 web-server               # Missing command
+# Test 3.1.1: Positional region + flag instance
+./ssm $TEST_REGION --instance $TEST_INSTANCE_1
+Expected: Connects to instance using mixed syntax
+
+# Test 3.1.2: Flag region + positional instance
+./ssm --region $TEST_REGION $TEST_INSTANCE_1
+Expected: Connects to instance using mixed syntax
+
+# Test 3.1.3: Exec with mixed syntax
+./ssm exec $TEST_REGION --instance $TEST_INSTANCE_1 --command "date"
+Expected: Executes command using mixed syntax
+
+# Test 3.1.4: Upload with mixed syntax
+./ssm upload $TEST_REGION --instance $TEST_INSTANCE_1 --local-file test-upload.txt --remote-path /tmp/mixed-upload.txt
+Expected: Uploads file using mixed syntax
+
+# Test 3.1.5: Invalid mixed syntax
+./ssm --region $TEST_REGION $TEST_INSTANCE_1 $TEST_INSTANCE_2
+Expected: Error - too many positional arguments
 ```
 
-## QA Checklist
-- [ ] Basic commands work
-- [ ] Instance listing works
-- [ ] Connect with Instance ID works
-- [ ] Connect with instance name works (NEW)
-- [ ] Exec with Instance ID works  
-- [ ] Exec with instance name works (NEW)
-- [ ] Tagged execution works
-- [ ] Small file upload works (< 1MB, direct SSM) (NEW)
-- [ ] Small file download works (< 1MB, direct SSM) (NEW)
-- [ ] Large file upload works (≥ 1MB, S3 intermediary) (NEW)
-- [ ] Large file download works (≥ 1MB, S3 intermediary) (NEW)
-- [ ] File transfer with instance names works (NEW)
-- [ ] File transfer to nested directories works (NEW)
-- [ ] File transfer error handling works (NEW)
-- [ ] IAM error handling works (basic validation)
-- [ ] S3 bucket auto-creation works (NEW)
-- [ ] S3 file auto-cleanup works (24hr lifecycle) (NEW)
-- [ ] Error handling is clear
-- [ ] No regressions
+### 4. Error Handling Tests
 
-## EC2 Test Instance Management (NEW)
-For comprehensive testing, use the EC2 manager script to create and destroy test instances:
+#### Test 4.1: Invalid Flags
+**Objective**: Test error handling for invalid parameters
 
+**Test Cases**:
 ```bash
-# Create test instances for QA testing
-./tools/01_ec2_test_manager.sh create --count 2 --owner QA-Team --name-prefix test-instance
+# Test 4.1.1: Unknown flag
+./ssm --unknown-flag
+Expected: Error message about unknown flag
 
-# List created instances to get IDs and names
-./tools/01_ec2_test_manager.sh verify
+# Test 4.1.2: Missing flag value
+./ssm --region
+Expected: Error message about missing value
 
-# Run QA tests with the created instances
-# (Replace instance IDs/names in test commands above with actual values)
+# Test 4.1.3: Invalid region
+./ssm --region invalid-region-code
+Expected: Error message about invalid region
 
-# Clean up test instances after testing
-./tools/01_ec2_test_manager.sh delete
+# Test 4.1.4: Missing required parameters for exec
+./ssm --exec --region $TEST_REGION
+Expected: Error message about missing instance
 
-# Create instances with custom settings
-./tools/01_ec2_test_manager.sh create --count 1 --name-prefix qa-server --owner QA-Team
+# Test 4.1.5: Missing command for exec
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1
+Expected: Error message about missing command
 ```
 
-## Advanced File Transfer Testing (NEW)
-Additional comprehensive tests for the file transfer functionality:
+#### Test 4.2: Conflicting Operations
+**Objective**: Test validation of mutually exclusive operations
 
+**Test Cases**:
 ```bash
-# Test file transfer with various file types and sizes
-# Create test files of different sizes
-echo "Small test content" > test_tiny.txt                               # Very small file
-dd if=/dev/zero of=test_medium.txt bs=512K count=1                      # 512KB file  
-dd if=/dev/zero of=test_boundary.txt bs=1M count=1                      # Exactly 1MB (boundary test)
-dd if=/dev/zero of=test_large_2mb.txt bs=1M count=2                     # 2MB file
-dd if=/dev/zero of=test_large_10mb.txt bs=1M count=10                   # 10MB file
+# Test 4.2.1: Multiple operations
+./ssm --exec --upload --region $TEST_REGION --instance $TEST_INSTANCE_1
+Expected: Should infer operation or handle gracefully
 
-# Test boundary conditions (files around 1MB threshold)
-./ssm upload cac1 web-server test_medium.txt /tmp/test_medium.txt       # Should use SSM direct
-./ssm upload cac1 web-server test_boundary.txt /tmp/test_boundary.txt   # Should use S3
-./ssm upload cac1 web-server test_large_2mb.txt /tmp/test_large_2mb.txt # Should use S3
+# Test 4.2.2: Incomplete parameter sets
+./ssm --upload --region $TEST_REGION --instance $TEST_INSTANCE_1
+Expected: Error about missing local-file and remote-path
 
-# Test download of various sizes
-./ssm download cac1 web-server /tmp/test_medium.txt ./downloaded_medium.txt
-./ssm download cac1 web-server /tmp/test_boundary.txt ./downloaded_boundary.txt
-./ssm download cac1 web-server /tmp/test_large_2mb.txt ./downloaded_large_2mb.txt
-
-# Test concurrent file transfers (if needed)
-./ssm upload cac1 test-instance-1 test_small.txt /tmp/concurrent1.txt &
-./ssm upload cac1 test-instance-2 test_small.txt /tmp/concurrent2.txt &
-wait
-
-# Test file transfers with special characters in paths
-./ssm upload cac1 web-server test_small.txt "/tmp/path with spaces/test file.txt"
-./ssm download cac1 web-server "/tmp/path with spaces/test file.txt" "./downloaded with spaces.txt"
-
-# Test permission edge cases
-./ssm exec cac1 web-server 'sudo mkdir -p /opt/restricted && sudo chmod 755 /opt/restricted'
-./ssm upload cac1 web-server test_small.txt /opt/restricted/test.txt    # Should work
-./ssm exec cac1 web-server 'sudo chmod 000 /opt/restricted'
-./ssm upload cac1 web-server test_small.txt /opt/restricted/fail.txt    # Should fail gracefully
-
-# Test S3 error scenarios (simulate network issues)
-# Note: These tests require manual intervention to simulate network issues
-# ./ssm upload cac1 web-server test_large_10mb.txt /tmp/test_large.txt   # Disconnect network during transfer
+# Test 4.2.3: Invalid instance identifier
+./ssm --region $TEST_REGION --instance invalid-instance-id
+Expected: Error message about invalid instance format
 ```
 
-## Performance and Reliability Testing (NEW)
+### 5. Edge Case Tests
+
+#### Test 5.1: Boundary Conditions
+**Objective**: Test edge cases and boundary conditions
+
+**Test Cases**:
 ```bash
-# Test large file transfer reliability
-./ssm upload cac1 web-server test_large_10mb.txt /tmp/perf_test.txt
-./ssm exec cac1 web-server 'md5sum /tmp/perf_test.txt'                  # Verify integrity
-md5sum test_large_10mb.txt                                              # Compare checksums
+# Test 5.1.1: Empty values
+./ssm --region "" --list
+Expected: Error or uses default region
 
-# Test file transfer with very long paths
-./ssm exec cac1 web-server 'mkdir -p /tmp/very/deep/nested/directory/structure/for/testing/purposes'
-./ssm upload cac1 web-server test_small.txt /tmp/very/deep/nested/directory/structure/for/testing/purposes/deep_file.txt
+# Test 5.1.2: Very long command
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "$(printf 'echo %.0s' {1..1000})"
+Expected: Handles long commands gracefully
 
-# Test multiple rapid transfers
-for i in {1..5}; do
-    echo "Test file $i" > "test_rapid_$i.txt"
-    ./ssm upload cac1 web-server "test_rapid_$i.txt" "/tmp/rapid_$i.txt"
-done
+# Test 5.1.3: Special characters in command
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "echo 'test with spaces and \"quotes\"'"
+Expected: Handles special characters correctly
 
-# Test S3 bucket lifecycle and cleanup (wait 25+ hours to verify automatic cleanup)
-# Note: This is a long-running test - document S3 objects created during testing
-./ssm upload cac1 web-server test_large_2mb.txt /tmp/lifecycle_test.txt
-# Check S3 console after 25 hours to verify automatic cleanup
-
-# Test concurrent file transfers (core functionality)
-echo "Concurrent test 1" > test_concurrent1.txt
-echo "Concurrent test 2" > test_concurrent2.txt
-(./ssm upload cac1 web-server test_concurrent1.txt /tmp/concurrent1.txt &
- ./ssm upload cac1 web-server test_concurrent2.txt /tmp/concurrent2.txt &
- wait)
+# Test 5.1.4: Unicode in file paths (if supported)
+./ssm --upload --region $TEST_REGION --instance $TEST_INSTANCE_1 --local-file test-upload.txt --remote-path "/tmp/test-файл.txt"
+Expected: Handles Unicode paths correctly
 ```
 
-## New Features (Developers add here)
-When adding new features, developers must:
-1. Add test commands below showing the new functionality
-2. Test that existing core features (connect, exec, exec-tagged) still work with the new feature
-3. Run full end-to-end testing to ensure no regressions
+#### Test 5.2: Environment Variables
+**Objective**: Test interaction with environment variables
 
+**Test Cases**:
 ```bash
-# File Transfer Feature - Added in feature/ssm-file-transfer branch
-# Test both small and large file transfers to ensure no regressions
-./ssm upload cac1 web-server test_small.txt /tmp/regression_test.txt
-./ssm exec cac1 web-server 'ls -la /tmp/regression_test.txt'
-./ssm download cac1 web-server /tmp/regression_test.txt ./regression_downloaded.txt
+# Test 5.2.1: SSM_DEBUG environment variable
+export SSM_DEBUG=true
+./ssm --region $TEST_REGION --list
+Expected: Shows debug information
 
-# Add new test commands when implementing features
-# Example: ./ssm new-command cac1 web-server 'test'
+# Test 5.2.2: AWS environment variables
+export AWS_DEFAULT_REGION=$TEST_REGION
+./ssm --instance $TEST_INSTANCE_1
+Expected: Uses environment region if available
+
+# Test 5.2.3: Clean up environment
+unset SSM_DEBUG AWS_DEFAULT_REGION
 ```
 
-## Test Cleanup (NEW)
-After running file transfer tests, clean up test files:
+### 6. Integration Tests
 
+#### Test 6.1: Full Workflow Tests
+**Objective**: Test complete workflows with new syntax
+
+**Test Cases**:
 ```bash
-# Remove local test files
-rm -f test_small.txt test_large.txt downloaded_*.txt regression_downloaded.txt
-rm -f test_tiny.txt test_medium.txt test_boundary.txt test_large_2mb.txt test_large_10mb.txt
-rm -f test_rapid_*.txt "downloaded with spaces.txt"
-rm -f test_concurrent*.txt
+# Test 6.1.1: Complete file transfer workflow
+./ssm --upload --region $TEST_REGION --instance $TEST_INSTANCE_1 --local-file test-upload.txt --remote-path /tmp/integration-test.txt
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "cat /tmp/integration-test.txt"
+./ssm --download --region $TEST_REGION --instance $TEST_INSTANCE_1 --remote-file /tmp/integration-test.txt --local-path ./test-downloads/integration-downloaded.txt
+Expected: Complete workflow works end-to-end
 
-# Clean up remote test files (optional - they don't consume much space)
-./ssm exec cac1 i-1234567890abcdef0 'rm -f /tmp/test_*.txt /tmp/regression_test.txt /tmp/rapid_*.txt /tmp/perf_test.txt /tmp/lifecycle_test.txt /tmp/concurrent*.txt'
-./ssm exec cac1 web-server 'rm -f /tmp/test_*.txt /tmp/regression_test.txt /tmp/rapid_*.txt /tmp/perf_test.txt /tmp/lifecycle_test.txt /tmp/concurrent*.txt'
-./ssm exec cac1 web-server 'rm -rf "/tmp/path with spaces" /tmp/very/deep/nested/directory /opt/restricted'
+# Test 6.1.2: Command execution workflow
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "echo 'test' > /tmp/command-test.txt"
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "ls -la /tmp/command-test.txt"
+Expected: Command sequence works correctly
 
-# Clean up test instances (if using ec2 test manager script)
-./tools/01_ec2_test_manager.sh delete
-
-# Note: S3 files are automatically cleaned up after 24 hours via lifecycle policy
-# S3 bucket remains for future use to avoid recreation costs
+# Test 6.1.3: Mixed syntax workflow
+./ssm $TEST_REGION --instance $TEST_INSTANCE_1  # Connect and verify
+./ssm exec $TEST_REGION --instance $TEST_INSTANCE_1 --command "uptime"  # Execute command
+Expected: Mixed syntax works in workflow
 ```
+
+#### Test 6.2: Instance Management
+**Objective**: Test instance discovery and management
+
+**Test Cases**:
+```bash
+# Test 6.2.1: List instances
+./ssm --region $TEST_REGION --list
+Expected: Shows list of available instances
+
+# Test 6.2.2: Instance name resolution
+./ssm --region $TEST_REGION --instance "test-instance-name"
+Expected: Resolves instance name to ID (if instance has Name tag)
+
+# Test 6.2.3: Tag-based operations
+./ssm --exec-tagged --region $TEST_REGION --tag-key $TEST_TAG_KEY --tag-value $TEST_TAG_VALUE --command "uptime"
+Expected: Executes on all instances matching tag
+```
+
+## Performance Tests
+
+### Test 7.1: Parser Performance
+**Objective**: Ensure parameter parsing doesn't impact performance
+
+**Test Cases**:
+```bash
+# Test 7.1.1: Parse time measurement
+time ./ssm --help
+Expected: Parsing completes in <100ms
+
+# Test 7.1.2: Large argument list
+./ssm --exec --region $TEST_REGION --instance $TEST_INSTANCE_1 --command "echo test" --debug
+Expected: Handles multiple flags efficiently
+
+# Test 7.1.3: Repeated operations
+for i in {1..5}; do time ./ssm --region $TEST_REGION --list > /dev/null; done
+Expected: Consistent performance across multiple runs
+```
+
+## Regression Tests
+
+### Test 8.1: Existing Scripts
+**Objective**: Ensure existing automation scripts continue to work
+
+**Test Cases**:
+```bash
+# Test 8.1.1: CI/CD script compatibility
+# Create test script using old syntax
+cat > test-old-syntax.sh << 'EOF'
+#!/bin/bash
+./ssm check
+./ssm $TEST_REGION
+./ssm exec $TEST_REGION $TEST_INSTANCE_1 "echo 'CI test'"
+EOF
+chmod +x test-old-syntax.sh
+./test-old-syntax.sh
+Expected: Script runs without modification
+
+# Test 8.1.2: Existing aliases
+alias quick-connect='./ssm $TEST_REGION $TEST_INSTANCE_1'
+quick-connect
+Expected: Alias works unchanged
+
+# Test 8.1.3: Clean up
+rm test-old-syntax.sh
+unalias quick-connect
+```
+
+## Test Execution Checklist
+
+### Pre-Test Setup
+- [ ] AWS CLI configured with test credentials
+- [ ] Test instances available and SSM-enabled
+- [ ] Test region and instance IDs configured
+- [ ] Test files created for upload/download tests
+- [ ] Test environment isolated from production
+
+### Test Execution
+- [ ] Run all backward compatibility tests
+- [ ] Run all flag-based parameter tests
+- [ ] Run all mixed syntax tests
+- [ ] Run all error handling tests
+- [ ] Run all edge case tests
+- [ ] Run all integration tests
+- [ ] Run performance tests
+- [ ] Run regression tests
+
+### Post-Test Validation
+- [ ] All tests pass
+- [ ] No performance degradation
+- [ ] Error messages are clear and helpful
+- [ ] Help documentation is accurate
+- [ ] Backward compatibility maintained
+
+## Expected Results
+
+### Success Criteria
+1. **100% Backward Compatibility**: All existing commands work unchanged
+2. **Flag Support**: All new flag-based syntax works correctly
+3. **Mixed Syntax**: Positional + flag combinations work as expected
+4. **Error Handling**: Clear, helpful error messages for invalid inputs
+5. **Performance**: No measurable performance impact
+6. **Documentation**: Help text accurately reflects both syntaxes
+
+### Failure Criteria
+1. Any existing command fails or behaves differently
+2. Flag-based syntax doesn't work as documented
+3. Error messages are unclear or unhelpful
+4. Performance degradation >10%
+5. Help documentation is inaccurate
+
+## Test Data Cleanup
+
+After testing, clean up test data:
+```bash
+# Remove test files
+rm -f test-upload.txt
+rm -rf test-downloads/
+
+# Clean up remote test files (if needed)
+./ssm exec $TEST_REGION $TEST_INSTANCE_1 "rm -f /tmp/test-*.txt /tmp/integration-test.txt /tmp/command-test.txt /tmp/mixed-upload.txt /tmp/flag-upload.txt"
+
+# Clear environment variables
+unset TEST_REGION TEST_INSTANCE_1 TEST_INSTANCE_2 TEST_TAG_KEY TEST_TAG_VALUE
+```
+
+## Reporting
+
+### Test Report Template
+```
+SSM Flag-Based Parameters Test Report
+=====================================
+
+Test Date: [DATE]
+Tester: [NAME]
+Environment: [OS/Version]
+AWS Region: [REGION]
+Test Instances: [INSTANCE_IDS]
+
+Summary:
+- Total Tests: [NUMBER]
+- Passed: [NUMBER]
+- Failed: [NUMBER]
+- Skipped: [NUMBER]
+
+Key Findings:
+- [List any issues found]
+- [Performance observations]
+- [User experience notes]
+
+Backward Compatibility:
+- [Status of existing functionality]
+- [Any breaking changes detected]
+
+New Features:
+- [Flag-based syntax validation]
+- [Mixed syntax validation]
+- [Error handling validation]
+
+Recommendations:
+- [Any changes needed]
+- [Additional testing required]
+
+Status: [PASS/FAIL/NEEDS_REVISION]
+```
+
+## Maintenance
+
+### Ongoing Testing
+- Run regression tests after any SSM changes
+- Test new flag combinations as they're added
+- Monitor performance impact over time
+- Update test cases for new features
+
+### Test Case Updates
+- Add test cases for new flags
+- Update expected results for changed behavior
+- Remove obsolete test cases
+- Add performance benchmarks for new features

--- a/tests/QA_SSM_TESTS.md
+++ b/tests/QA_SSM_TESTS.md
@@ -34,15 +34,41 @@ This QA document uses `./ssm` to test the local development version before insta
 - Proper IAM permissions for SSM Session Manager
 
 ### Test Data Setup
+
+**Step 1: Create Environment File**
 ```bash
-# Ensure test instances are available
-# ⚠️  WARNING: Replace placeholder values with your actual AWS resources
-# Do not commit real instance IDs to version control
-export TEST_REGION="<YOUR_AWS_REGION>"              # e.g., "us-east-1", "ca-central-1"
-export TEST_INSTANCE_1="<YOUR_INSTANCE_ID_1>"       # e.g., "i-1234567890abcdef0"
-export TEST_INSTANCE_2="<YOUR_INSTANCE_ID_2>"       # e.g., "i-0987654321fedcba0"  
-export TEST_TAG_KEY="<YOUR_TAG_KEY>"                # e.g., "Environment"
-export TEST_TAG_VALUE="<YOUR_TAG_VALUE>"            # e.g., "test"
+# Create a test configuration file (NOT committed to version control)
+cat > test-config.env << 'EOF'
+# ⚠️  WARNING: Replace with your actual AWS resources
+# This file should be added to .gitignore
+export TEST_REGION="us-east-1"                      # Your test region
+export TEST_INSTANCE_1="i-1234567890abcdef0"        # Your test instance 1
+export TEST_INSTANCE_2="i-0987654321fedcba0"        # Your test instance 2
+export TEST_TAG_KEY="Environment"                   # Your test tag key
+export TEST_TAG_VALUE="test"                        # Your test tag value
+EOF
+
+# Load test configuration
+source test-config.env
+```
+
+**Step 2: Validate Test Data**
+```bash
+# Validate instance ID format before running tests
+validate_instance_id() {
+    local instance_id="$1"
+    if [[ ! "$instance_id" =~ ^i-[0-9a-f]{8,17}$ ]]; then
+        echo "❌ Invalid instance ID format: $instance_id"
+        echo "Expected format: i-xxxxxxxxxxxxxxxx (8-17 hex characters)"
+        return 1
+    fi
+    echo "✅ Valid instance ID format: $instance_id"
+    return 0
+}
+
+# Validate all test data before proceeding
+validate_instance_id "$TEST_INSTANCE_1" || exit 1
+validate_instance_id "$TEST_INSTANCE_2" || exit 1
 
 # Create test files for upload/download testing
 echo "Test content for upload" > test-upload.txt

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+
+# ZTiAWS Uninstallation Script
+# Remove ZTiAWS tools from system
+
+set -e  # Exit on any error
+
+# Color output for better UX
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_color() {
+    local color=$1
+    local message=$2
+    echo -e "${color}${message}${NC}"
+}
+
+# Function to check what's installed
+check_installation() {
+    print_color $BLUE "🔍 Checking current installation..."
+    
+    local found_files=()
+    
+    # Check for authaws
+    if [[ -f "/usr/local/bin/authaws" ]]; then
+        found_files+=("/usr/local/bin/authaws")
+        print_color $YELLOW "  • Found: /usr/local/bin/authaws"
+    fi
+    
+    # Check for ssm
+    if [[ -f "/usr/local/bin/ssm" ]]; then
+        found_files+=("/usr/local/bin/ssm")
+        print_color $YELLOW "  • Found: /usr/local/bin/ssm"
+    fi
+    
+    # Check for src directory
+    if [[ -d "/usr/local/bin/src" ]]; then
+        local src_files=$(find /usr/local/bin/src -name "*.sh" 2>/dev/null | wc -l)
+        if [[ $src_files -gt 0 ]]; then
+            found_files+=("/usr/local/bin/src")
+            print_color $YELLOW "  • Found: /usr/local/bin/src (with $src_files .sh files)"
+        fi
+    fi
+    
+    if [[ ${#found_files[@]} -eq 0 ]]; then
+        print_color $GREEN "✅ No ZTiAWS installation found"
+        print_color $BLUE "Nothing to uninstall."
+        exit 0
+    fi
+    
+    echo
+    print_color $YELLOW "Found ${#found_files[@]} ZTiAWS component(s) to remove."
+    return 0
+}
+
+# Function to confirm uninstallation
+confirm_uninstall() {
+    if [[ "$1" != "--yes" ]] && [[ "$1" != "-y" ]]; then
+        print_color $RED "⚠️  This will permanently remove ZTiAWS from your system."
+        echo
+        read -p "Are you sure you want to continue? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            print_color $BLUE "Uninstallation cancelled."
+            exit 0
+        fi
+    fi
+}
+
+# Function to remove files
+remove_files() {
+    print_color $BLUE "🗑️  Removing ZTiAWS files..."
+    
+    local removed_count=0
+    
+    # Remove authaws
+    if [[ -f "/usr/local/bin/authaws" ]]; then
+        print_color $BLUE "  • Removing authaws..."
+        if sudo rm -f /usr/local/bin/authaws; then
+            print_color $GREEN "    ✅ Removed /usr/local/bin/authaws"
+            ((removed_count++))
+        else
+            print_color $RED "    ❌ Failed to remove /usr/local/bin/authaws"
+        fi
+    fi
+    
+    # Remove ssm
+    if [[ -f "/usr/local/bin/ssm" ]]; then
+        print_color $BLUE "  • Removing ssm..."
+        if sudo rm -f /usr/local/bin/ssm; then
+            print_color $GREEN "    ✅ Removed /usr/local/bin/ssm"
+            ((removed_count++))
+        else
+            print_color $RED "    ❌ Failed to remove /usr/local/bin/ssm"
+        fi
+    fi
+    
+    # Remove src directory
+    if [[ -d "/usr/local/bin/src" ]]; then
+        print_color $BLUE "  • Removing source modules..."
+        if sudo rm -rf /usr/local/bin/src; then
+            print_color $GREEN "    ✅ Removed /usr/local/bin/src"
+            ((removed_count++))
+        else
+            print_color $RED "    ❌ Failed to remove /usr/local/bin/src"
+        fi
+    fi
+    
+    echo
+    if [[ $removed_count -gt 0 ]]; then
+        print_color $GREEN "✅ Removed $removed_count ZTiAWS component(s)"
+    else
+        print_color $RED "❌ No files were removed"
+        return 1
+    fi
+}
+
+# Function to verify removal
+verify_removal() {
+    print_color $BLUE "🧪 Verifying removal..."
+    
+    local remaining_files=()
+    
+    # Check if anything is left
+    if command -v authaws &> /dev/null; then
+        remaining_files+=("authaws")
+    fi
+    
+    if command -v ssm &> /dev/null; then
+        remaining_files+=("ssm")
+    fi
+    
+    if [[ ${#remaining_files[@]} -gt 0 ]]; then
+        print_color $RED "❌ Some files may still be accessible:"
+        for file in "${remaining_files[@]}"; do
+            print_color $YELLOW "  • $file: $(which $file)"
+        done
+        print_color $YELLOW "Note: These may be from a different installation location"
+        return 1
+    else
+        print_color $GREEN "✅ ZTiAWS commands are no longer accessible"
+        return 0
+    fi
+}
+
+# Function to show cleanup suggestions
+show_cleanup_suggestions() {
+    print_color $BLUE "🧹 Additional Cleanup (Optional):"
+    echo
+    print_color $YELLOW "You may also want to remove:"
+    echo "  • AWS CLI credentials: ~/.aws/"
+    echo "  • ZTiAWS configuration: ~/.env files"
+    echo "  • Any custom aliases or PATH modifications"
+    echo
+    print_color $BLUE "These are not removed automatically for safety."
+}
+
+# Main uninstallation function
+main() {
+    print_color $RED "🗑️  ZTiAWS Uninstallation"
+    print_color $BLUE "======================================"
+    echo
+    print_color $BLUE "Removing ZTiAWS (ZSoftly Tools for AWS) from your system"
+    echo
+    
+    check_installation
+    confirm_uninstall "$1"
+    
+    if remove_files; then
+        if verify_removal; then
+            show_cleanup_suggestions
+            print_color $GREEN "✅ ZTiAWS uninstallation completed successfully!"
+        else
+            print_color $YELLOW "⚠️  Uninstallation completed with warnings (see above)"
+        fi
+    else
+        print_color $RED "❌ Uninstallation failed"
+        print_color $YELLOW "Some files may still be present on your system"
+        exit 1
+    fi
+}
+
+# Show help if requested
+if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    print_color $RED "ZTiAWS Uninstallation Script"
+    echo
+    print_color $BLUE "USAGE:"
+    echo "  ./uninstall.sh         # Remove ZTiAWS (with confirmation)"
+    echo "  ./uninstall.sh --yes   # Remove ZTiAWS (no confirmation)"
+    echo "  ./uninstall.sh --help  # Show this help"
+    echo
+    print_color $BLUE "DESCRIPTION:"
+    echo "  Removes ZTiAWS bash tools (authaws, ssm) from /usr/local/bin"
+    echo "  Requires sudo permissions for removal."
+    echo
+    print_color $BLUE "WHAT GETS REMOVED:"
+    echo "  • /usr/local/bin/authaws"
+    echo "  • /usr/local/bin/ssm"
+    echo "  • /usr/local/bin/src/*.sh (source modules)"
+    echo
+    print_color $BLUE "WHAT IS PRESERVED:"
+    echo "  • AWS CLI configuration (~/.aws/)"
+    echo "  • Personal configuration files"
+    echo "  • Custom aliases or PATH modifications"
+    echo
+    exit 0
+fi
+
+# Run main uninstallation
+main "$@"


### PR DESCRIPTION
- Add src/07_ssm_parameter_parser.sh following authaws pattern
- Support both positional and flag-based syntax with full backward compatibility
- Add mixed syntax support (positional + flags)
- Update ssm script to use new parameter parser
- Add comprehensive help text showing both syntaxes
- Update README.md with examples of new flag syntax
- Create QA_SSM_TESTS.md for comprehensive testing
- Fix region validation for mixed syntax scenarios
- Add short flags (-h, -v, -r, -i) for common operations

New flag syntax examples:
- ssm --region cac1 --instance i-1234
- ssm --help, ssm -h
- ssm --version, ssm -v
- ssm --check
- ssm exec --region use1 --instance i-1234 --command 'df -h'

Backward compatibility maintained:
- All existing positional syntax continues to work unchanged
- ssm cac1 i-1234, ssm check, ssm help, etc.

Resolves #33