### PR TITLE
feat: switch from SHA256 to SHA1 for cache filename generation to ensure AWS CLI compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,12 +254,12 @@ jobs:
         
         # Run golangci-lint with security linters enabled
         echo "Running golangci-lint with security checks..."
-        $(go env GOPATH)/bin/golangci-lint run --enable gosec --out-format json > golangci-security-report.json || true
+        $(go env GOPATH)/bin/golangci-lint run --enable gosec --out-format=json > golangci-security-report.json || true
         $(go env GOPATH)/bin/golangci-lint run --enable gosec || true
         
         # Try to install and run standalone gosec as backup
         echo "Installing standalone GoSec..."
-        curl -sfL https://raw.githubusercontent.com/securecodewarrior/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest || true
+        curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest || true
         
         if [ -f "$(go env GOPATH)/bin/gosec" ]; then
           echo "Running standalone GoSec analysis..."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         
     - name: Get dependencies
       working-directory: ./ztictl
@@ -219,7 +219,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         
     - name: Download dependencies
       working-directory: ./ztictl
@@ -230,8 +230,9 @@ jobs:
         # Install govulncheck for official Go vulnerability checking
         go install golang.org/x/vuln/cmd/govulncheck@latest
         
-        # Install golangci-lint for comprehensive linting and security checks
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin latest
+        # Install golangci-lint v2.4.0 for comprehensive linting and security checks
+        # Using specific version to match local development environment
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.4.0
         
         # Verify installations
         govulncheck -version || echo "govulncheck installation failed"
@@ -408,7 +409,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         
     - name: Get dependencies
       working-directory: ./ztictl

--- a/ztictl/.golangci.yml
+++ b/ztictl/.golangci.yml
@@ -1,59 +1,107 @@
-linters:
-  enable:
-    - errcheck
-    - gosec
-    - ineffassign
-    - staticcheck
-    - unused
-    - govet
-    - gofmt
-    - goimports
-    - misspell
-    - revive
+# golangci-lint configuration for ztictl
+# Compatible with golangci-lint v2.4.0 - modernized configuration
 
-linters-settings:
-  gosec:
-    excludes:
-      - G401 # Use of weak cryptographic primitive - SHA1 required for AWS CLI compatibility
-      - G505 # Import of weak cryptographic primitive - SHA1 required for AWS CLI compatibility
-    config:
-      G401:
-        # Allow SHA1 only for AWS SSO token cache filename generation
-        # This is required for AWS CLI compatibility
-        exclude-dirs:
-          - internal/auth
-      G505:
-        # Allow SHA1 import only for AWS SSO token cache
-        exclude-dirs:
-          - internal/auth
-
-issues:
-  exclude-rules:
-    # Exclude SHA1 usage in auth package - required for AWS CLI compatibility
-    - path: internal/auth/sso\.go
-      linters:
-        - gosec
-      text: "(G401|G505)"
-    
-    # Allow unchecked errors in test files for cleanup operations
-    - path: _test\.go
-      linters:
-        - errcheck
-      text: "Error return value of .*(Close|Setenv|RemoveAll|Chmod).* is not checked"
-
-    # Allow unchecked errors for deferred cleanup operations
-    - path: \.go
-      linters:
-        - errcheck
-      source: "defer.*\\.Close\\(\\)"
+version: "2"
 
 run:
-  timeout: 5m
-  tests: true
   build-tags:
     - integration
+  tests: true
 
-output:
-  format: colored-line-number
-  print-issued-lines: true
-  print-linter-name: true
+linters:
+  enable:
+    # Core linters
+    - errcheck      # checks for unchecked errors
+    - gosec         # inspects source code for security problems  
+    - ineffassign   # detects when assignments to existing variables are not used
+    - staticcheck   # advanced static analyzer
+    - unused        # checks for unused constants, variables, functions and types
+    - govet         # reports suspicious constructs
+    # Additional modern linters for better code quality
+    - bodyclose      # checks whether HTTP response body is closed
+    - contextcheck   # checks for common mistakes in using contexts
+    - errorlint      # finds code that will cause problems with Go 1.13 error wrapping
+    - gocritic       # provides diagnostics that check for bugs, performance and style issues
+    - misspell       # finds commonly misspelled English words in comments
+    - nilerr         # finds the code that returns nil even if it checks that the error is not nil
+    - nolintlint     # reports ill-formed or insufficient nolint directives
+    - prealloc       # finds slice declarations that could potentially be pre-allocated
+    - revive         # fast, configurable, extensible, flexible, and beautiful linter for Go
+    - rowserrcheck   # checks whether Err of rows is checked successfully
+    - unconvert      # removes unnecessary type conversions
+    - wastedassign   # finds wasted assignment statements
+
+  settings:
+    gocritic:
+      # Enable stable checks only for consistent code quality
+      enabled-checks:
+        - appendAssign
+        - argOrder
+        - assignOp
+        - badCall
+        - badCond
+        - caseOrder
+        - defaultCaseOrder
+        - dupArg
+        - dupBranchBody
+        - dupCase
+        - flagDeref
+        - ifElseChain
+    
+    gosec:
+      # To select a subset of rules to exclude
+      excludes:
+        - G401 # Use of weak cryptographic primitive - SHA1 required for AWS CLI compatibility
+        - G505 # Import blocklist: crypto/sha1 - SHA1 required for AWS CLI compatibility
+    
+    revive:
+      # Set minimum confidence for revive to reduce false positives
+      confidence: 0.8
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      # Exclude SHA1 usage in auth package - required for AWS CLI compatibility
+      - linters:
+          - gosec
+        path: internal/auth/sso\.go
+        text: (G401|G505)
+      
+      # Allow unchecked errors in test files for cleanup operations
+      - linters:
+          - errcheck
+        path: _test\.go
+        text: Error return value of .*(Close|Setenv|RemoveAll|Chmod).* is not checked
+
+      # Allow unchecked errors for deferred cleanup operations
+      - linters:
+          - errcheck
+        path: \.go
+        source: defer.*\.Close\(\)
+      
+      # Allow longer lines in generated files
+      - linters:
+          - lll
+        path: .*\.pb\.go$
+    
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  enable:
+    - gofmt        # formats Go programs
+    - goimports    # updates Go import lines
+  
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/ztictl/.golangci.yml
+++ b/ztictl/.golangci.yml
@@ -1,0 +1,59 @@
+linters:
+  enable:
+    - errcheck
+    - gosec
+    - ineffassign
+    - staticcheck
+    - unused
+    - govet
+    - gofmt
+    - goimports
+    - misspell
+    - revive
+
+linters-settings:
+  gosec:
+    excludes:
+      - G401 # Use of weak cryptographic primitive - SHA1 required for AWS CLI compatibility
+      - G505 # Import of weak cryptographic primitive - SHA1 required for AWS CLI compatibility
+    config:
+      G401:
+        # Allow SHA1 only for AWS SSO token cache filename generation
+        # This is required for AWS CLI compatibility
+        exclude-dirs:
+          - internal/auth
+      G505:
+        # Allow SHA1 import only for AWS SSO token cache
+        exclude-dirs:
+          - internal/auth
+
+issues:
+  exclude-rules:
+    # Exclude SHA1 usage in auth package - required for AWS CLI compatibility
+    - path: internal/auth/sso\.go
+      linters:
+        - gosec
+      text: "(G401|G505)"
+    
+    # Allow unchecked errors in test files for cleanup operations
+    - path: _test\.go
+      linters:
+        - errcheck
+      text: "Error return value of .*(Close|Setenv|RemoveAll|Chmod).* is not checked"
+
+    # Allow unchecked errors for deferred cleanup operations
+    - path: \.go
+      linters:
+        - errcheck
+      source: "defer.*\\.Close\\(\\)"
+
+run:
+  timeout: 5m
+  tests: true
+  build-tags:
+    - integration
+
+output:
+  format: colored-line-number
+  print-issued-lines: true
+  print-linter-name: true

--- a/ztictl/internal/auth/sso.go
+++ b/ztictl/internal/auth/sso.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha1" // #nosec G505 -- SHA1 required for AWS CLI compatibility, not used for security
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -510,7 +510,11 @@ func (m *Manager) getCachedToken(startURL string) (*SSOToken, error) {
 	cacheDir := filepath.Join(homeDir, ".aws", "sso", "cache")
 
 	// First, try the expected filename based on SHA1 hash (AWS CLI compatible)
-	hasher := sha1.New()
+	// SECURITY NOTE: SHA1 is cryptographically weak but required for AWS CLI compatibility.
+	// The hash is only used for cache filename generation, not for security purposes.
+	// AWS CLI expects SHA1-based filenames in ~/.aws/sso/cache/
+	// TODO: Monitor AWS CLI for migration to SHA256 or other secure alternatives
+	hasher := sha1.New() // #nosec G401 -- SHA1 required for AWS CLI compatibility
 	hasher.Write([]byte(startURL))
 	hash := hex.EncodeToString(hasher.Sum(nil))
 	expectedFile := filepath.Join(cacheDir, fmt.Sprintf("%s.json", hash))
@@ -725,7 +729,11 @@ func (m *Manager) saveTokenToCache(tokenResp *ssooidc.CreateTokenOutput, startUR
 	}
 
 	// Generate cache filename (AWS CLI compatible using SHA1)
-	hasher := sha1.New()
+	// SECURITY NOTE: SHA1 is cryptographically weak but required for AWS CLI compatibility.
+	// The hash is only used for cache filename generation, not for security purposes.
+	// AWS CLI expects SHA1-based filenames in ~/.aws/sso/cache/
+	// TODO: Monitor AWS CLI for migration to SHA256 or other secure alternatives
+	hasher := sha1.New() // #nosec G401 -- SHA1 required for AWS CLI compatibility
 	hasher.Write([]byte(startURL))
 	hash := hex.EncodeToString(hasher.Sum(nil))
 	filename := fmt.Sprintf("%s.json", hash)

--- a/ztictl/internal/auth/sso.go
+++ b/ztictl/internal/auth/sso.go
@@ -2,7 +2,7 @@ package auth
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -509,8 +509,8 @@ func (m *Manager) getCachedToken(startURL string) (*SSOToken, error) {
 
 	cacheDir := filepath.Join(homeDir, ".aws", "sso", "cache")
 
-	// First, try the expected filename based on SHA256 hash
-	hasher := sha256.New()
+	// First, try the expected filename based on SHA1 hash (AWS CLI compatible)
+	hasher := sha1.New()
 	hasher.Write([]byte(startURL))
 	hash := hex.EncodeToString(hasher.Sum(nil))
 	expectedFile := filepath.Join(cacheDir, fmt.Sprintf("%s.json", hash))
@@ -724,8 +724,8 @@ func (m *Manager) saveTokenToCache(tokenResp *ssooidc.CreateTokenOutput, startUR
 		ExpiresAt:   expiresAt,
 	}
 
-	// Generate cache filename (AWS CLI compatible)
-	hasher := sha256.New()
+	// Generate cache filename (AWS CLI compatible using SHA1)
+	hasher := sha1.New()
 	hasher.Write([]byte(startURL))
 	hash := hex.EncodeToString(hasher.Sum(nil))
 	filename := fmt.Sprintf("%s.json", hash)

--- a/ztictl/internal/config/config_test.go
+++ b/ztictl/internal/config/config_test.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -230,7 +229,7 @@ func TestLoad(t *testing.T) {
 			name: "first run without env file",
 			setup: func() (cleanup func(), error error) {
 				// Create temp directory for config
-				tempDir, err := ioutil.TempDir("", "config_test")
+				tempDir, err := os.MkdirTemp("", "config_test")
 				if err != nil {
 					return nil, err
 				}
@@ -251,7 +250,7 @@ func TestLoad(t *testing.T) {
 		{
 			name: "first run with valid env file",
 			setup: func() (cleanup func(), error error) {
-				tempDir, err := ioutil.TempDir("", "config_test")
+				tempDir, err := os.MkdirTemp("", "config_test")
 				if err != nil {
 					return nil, err
 				}
@@ -264,7 +263,7 @@ LOG_DIR="/tmp/logs"
 `
 				envPath := filepath.Join("..", ".env")
 				_ = os.MkdirAll(filepath.Dir(envPath), 0750) // #nosec G104 - test setup
-				err = ioutil.WriteFile(envPath, []byte(envContent), 0600)
+				err = os.WriteFile(envPath, []byte(envContent), 0600)
 				if err != nil {
 					return nil, err
 				}
@@ -459,13 +458,13 @@ SSO_REGION=us-west-2
 
 			if tt.envContent != "" {
 				// Create temporary env file
-				tempDir, err := ioutil.TempDir("", "env_test")
+				tempDir, err := os.MkdirTemp("", "env_test")
 				if err != nil {
 					t.Fatalf("Failed to create temp directory: %v", err)
 				}
 
 				envPath = filepath.Join(tempDir, ".env")
-				err = ioutil.WriteFile(envPath, []byte(tt.envContent), 0600)
+				err = os.WriteFile(envPath, []byte(tt.envContent), 0600)
 				if err != nil {
 					t.Fatalf("Failed to write env file: %v", err)
 				}
@@ -502,7 +501,7 @@ func TestExists(t *testing.T) {
 		{
 			name: "config file exists",
 			setup: func() (cleanup func()) {
-				tempDir, err := ioutil.TempDir("", "config_exists_test")
+				tempDir, err := os.MkdirTemp("", "config_exists_test")
 				if err != nil {
 					t.Fatalf("Failed to create temp directory: %v", err)
 				}
@@ -518,7 +517,7 @@ func TestExists(t *testing.T) {
 				}
 
 				configPath := filepath.Join(tempDir, ".ztictl.yaml")
-				_ = ioutil.WriteFile(configPath, []byte("test: config"), 0600) // #nosec G104 - test setup
+				_ = os.WriteFile(configPath, []byte("test: config"), 0600) // #nosec G104 - test setup
 
 				return func() {
 					if runtime.GOOS == "windows" {
@@ -534,7 +533,7 @@ func TestExists(t *testing.T) {
 		{
 			name: "config file does not exist",
 			setup: func() (cleanup func()) {
-				tempDir, err := ioutil.TempDir("", "config_not_exists_test")
+				tempDir, err := os.MkdirTemp("", "config_not_exists_test")
 				if err != nil {
 					t.Fatalf("Failed to create temp directory: %v", err)
 				}
@@ -606,7 +605,7 @@ func TestGetConfigPath(t *testing.T) {
 
 func TestWriteInteractiveConfig(t *testing.T) {
 	// Create temporary home directory
-	tempDir, err := ioutil.TempDir("", "interactive_config_test")
+	tempDir, err := os.MkdirTemp("", "interactive_config_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -647,7 +646,7 @@ func TestWriteInteractiveConfig(t *testing.T) {
 	}
 
 	// Read and verify content
-	content, err := ioutil.ReadFile(configPath) // #nosec G304 - test file with controlled path
+	content, err := os.ReadFile(configPath) // #nosec G304 - test file with controlled path
 	if err != nil {
 		t.Fatalf("Failed to read config file: %v", err)
 	}
@@ -678,7 +677,7 @@ func TestInteractiveInit(t *testing.T) {
 	// We can't easily test the interactive input part without complex mocking
 
 	// Test that InteractiveInit exists and can handle setup errors
-	tempDir, err := ioutil.TempDir("", "interactive_init_test")
+	tempDir, err := os.MkdirTemp("", "interactive_init_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -975,7 +974,7 @@ func TestSetDefaultsWithViper(t *testing.T) {
 
 func TestLoadLegacyEnvFileErrorHandling(t *testing.T) {
 	// Test file permission error
-	tempDir, err := ioutil.TempDir("", "env_error_test")
+	tempDir, err := os.MkdirTemp("", "env_error_test")
 	if err != nil {
 		t.Fatalf("Failed to create temp directory: %v", err)
 	}
@@ -983,7 +982,7 @@ func TestLoadLegacyEnvFileErrorHandling(t *testing.T) {
 
 	// Create env file then make it unreadable
 	envPath := filepath.Join(tempDir, ".env")
-	err = ioutil.WriteFile(envPath, []byte("TEST=value"), 0600)
+	err = os.WriteFile(envPath, []byte("TEST=value"), 0600)
 	if err != nil {
 		t.Fatalf("Failed to create env file: %v", err)
 	}


### PR DESCRIPTION
- Problem: v2.6.0 broke AWS CLI compatibility by switching from SHA1 to SHA256 for SSO token cache filenames.
- Reverted hash algorithm back to SHA1 in ztictl/internal/auth/sso.go to match AWS CLI's expected cache file naming convention.