### PR TITLE
Implement Linux and Windows command builders for platform-specific operations

### DIFF
--- a/ztictl/go.mod
+++ b/ztictl/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.9.0 // indirect

--- a/ztictl/go.sum
+++ b/ztictl/go.sum
@@ -126,6 +126,7 @@ github.com/spf13/viper v1.18.2 h1:LUXCnvUvSM6FXAsj6nnfc8Q2tp1dIgUfY9Kc8GsSOiQ=
 github.com/spf13/viper v1.18.2/go.mod h1:EKmWIqdnk5lOcmR72yw6hS+8OPYcwD0jteitLMVB+yk=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/ztictl/internal/platform/builder.go
+++ b/ztictl/internal/platform/builder.go
@@ -1,0 +1,161 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// CommandBuilder defines the interface for platform-specific command construction
+type CommandBuilder interface {
+	// GetSSMDocument returns the appropriate SSM document name for the platform
+	GetSSMDocument() string
+
+	// BuildExecCommand wraps a command for execution with error handling
+	BuildExecCommand(command string) string
+
+	// BuildFileExistsCommand creates a command to check if a file exists
+	BuildFileExistsCommand(path string) string
+
+	// BuildFileSizeCommand creates a command to get the size of a file
+	BuildFileSizeCommand(path string) string
+
+	// BuildDirectoryCreateCommand creates a command to create a directory
+	BuildDirectoryCreateCommand(path string) string
+
+	// BuildFileReadCommand creates a command to read a file (base64 encoded)
+	BuildFileReadCommand(path string) string
+
+	// BuildFileWriteCommand creates a command to write base64 data to a file
+	BuildFileWriteCommand(path string, base64Data string) string
+
+	// BuildFileAppendCommand creates a command to append base64 data to a file
+	BuildFileAppendCommand(path string, base64Data string) string
+
+	// NormalizePath converts a path to the platform's format
+	NormalizePath(path string) string
+
+	// ParseExitCode extracts the exit code from command output
+	ParseExitCode(output string) (int, error)
+
+	// ParseFileSize extracts file size from command output
+	ParseFileSize(output string) (int64, error)
+
+	// ParseFileExists interprets command output to determine if file exists
+	ParseFileExists(output string, exitCode int) (bool, error)
+}
+
+// BuilderFactory creates the appropriate CommandBuilder for a platform
+type BuilderFactory struct{}
+
+// NewBuilderFactory creates a new BuilderFactory
+func NewBuilderFactory() *BuilderFactory {
+	return &BuilderFactory{}
+}
+
+// GetBuilder returns the appropriate CommandBuilder for the given platform
+func (f *BuilderFactory) GetBuilder(platform Platform) (CommandBuilder, error) {
+	switch platform {
+	case PlatformLinux:
+		return NewLinuxBuilder(), nil
+	case PlatformWindows:
+		return NewWindowsBuilder(), nil
+	default:
+		return nil, fmt.Errorf("unsupported platform: %s", platform)
+	}
+}
+
+// CommandContext provides context for command execution
+type CommandContext struct {
+	Platform    Platform
+	InstanceID  string
+	Region      string
+	WorkingDir  string
+	Environment map[string]string
+}
+
+// CommandResult represents the result of a command execution
+type CommandResult struct {
+	Output      string
+	ErrorOutput string
+	ExitCode    int
+	Success     bool
+}
+
+// BaseBuilder provides common functionality for all platform builders
+type BaseBuilder struct{}
+
+// SanitizePath removes potentially dangerous characters from paths
+func (b *BaseBuilder) SanitizePath(path string) string {
+	// Remove null bytes and other dangerous characters
+	path = strings.ReplaceAll(path, "\x00", "")
+	path = strings.ReplaceAll(path, "\n", "")
+	path = strings.ReplaceAll(path, "\r", "")
+
+	// Normalize path separators
+	path = filepath.Clean(path)
+
+	return path
+}
+
+// EscapeShellArg escapes a string for use as a shell argument
+func (b *BaseBuilder) EscapeShellArg(arg string) string {
+	// For Linux/Unix shells
+	if strings.Contains(arg, "'") {
+		// If the argument contains single quotes, use double quotes and escape
+		arg = strings.ReplaceAll(arg, "\\", "\\\\")
+		arg = strings.ReplaceAll(arg, "\"", "\\\"")
+		arg = strings.ReplaceAll(arg, "$", "\\$")
+		arg = strings.ReplaceAll(arg, "`", "\\`")
+		return fmt.Sprintf("\"%s\"", arg)
+	}
+	// Otherwise, use single quotes for simplicity
+	return fmt.Sprintf("'%s'", arg)
+}
+
+// BuilderManager manages command builders and platform detection
+type BuilderManager struct {
+	detector *Detector
+	factory  *BuilderFactory
+	builders map[string]CommandBuilder // Cache builders by instance ID
+}
+
+// NewBuilderManager creates a new BuilderManager
+func NewBuilderManager(detector *Detector) *BuilderManager {
+	return &BuilderManager{
+		detector: detector,
+		factory:  NewBuilderFactory(),
+		builders: make(map[string]CommandBuilder),
+	}
+}
+
+// GetBuilder gets or creates a CommandBuilder for an instance
+func (m *BuilderManager) GetBuilder(ctx context.Context, instanceID string) (CommandBuilder, error) {
+	// Check cache
+	if builder, exists := m.builders[instanceID]; exists {
+		return builder, nil
+	}
+
+	// Detect platform
+	result, err := m.detector.DetectPlatform(ctx, instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect platform: %w", err)
+	}
+
+	// Create builder
+	builder, err := m.factory.GetBuilder(result.Platform)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create builder: %w", err)
+	}
+
+	// Cache for future use
+	m.builders[instanceID] = builder
+
+	return builder, nil
+}
+
+// ClearCache clears the builder cache
+func (m *BuilderManager) ClearCache() {
+	m.builders = make(map[string]CommandBuilder)
+}

--- a/ztictl/internal/platform/detector.go
+++ b/ztictl/internal/platform/detector.go
@@ -1,0 +1,246 @@
+package platform
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"ztictl/pkg/logging"
+)
+
+// Platform represents the operating system platform
+type Platform string
+
+const (
+	// PlatformLinux represents Linux/Unix systems
+	PlatformLinux Platform = "Linux"
+	// PlatformWindows represents Windows systems
+	PlatformWindows Platform = "Windows"
+	// PlatformUnknown represents unknown platform
+	PlatformUnknown Platform = "Unknown"
+)
+
+// DetectionConfidence represents the confidence level of platform detection
+type DetectionConfidence int
+
+const (
+	// ConfidenceNone indicates no confidence in detection
+	ConfidenceNone DetectionConfidence = iota
+	// ConfidenceLow indicates low confidence (default fallback)
+	ConfidenceLow
+	// ConfidenceMedium indicates medium confidence (EC2 metadata)
+	ConfidenceMedium
+	// ConfidenceHigh indicates high confidence (SSM data)
+	ConfidenceHigh
+)
+
+// DetectionResult contains platform detection information
+type DetectionResult struct {
+	Platform        Platform
+	Confidence      DetectionConfidence
+	Source          string
+	DetectedAt      time.Time
+	PlatformName    string
+	PlatformVersion string
+}
+
+// Detector handles platform detection with caching
+type Detector struct {
+	ssmClient SSMClient
+	ec2Client EC2Client
+	cache     map[string]*DetectionResult
+	cacheMu   sync.RWMutex
+	cacheTTL  time.Duration
+}
+
+// NewDetector creates a new platform detector
+func NewDetector(ssmClient SSMClient, ec2Client EC2Client) *Detector {
+	return &Detector{
+		ssmClient: ssmClient,
+		ec2Client: ec2Client,
+		cache:     make(map[string]*DetectionResult),
+		cacheTTL:  15 * time.Minute,
+	}
+}
+
+// DetectPlatform detects the platform of an instance with hierarchical fallback
+func (d *Detector) DetectPlatform(ctx context.Context, instanceID string) (*DetectionResult, error) {
+	// Check cache first
+	if result := d.getCachedResult(instanceID); result != nil {
+		logging.LogDebug("Using cached platform for instance %s: %s", instanceID, result.Platform)
+		return result, nil
+	}
+
+	// Try SSM first (highest confidence)
+	if result, err := d.detectFromSSM(ctx, instanceID); err == nil && result.Confidence == ConfidenceHigh {
+		d.cacheResult(instanceID, result)
+		return result, nil
+	}
+
+	// Try EC2 (medium confidence)
+	if result, err := d.detectFromEC2(ctx, instanceID); err == nil && result.Confidence >= ConfidenceMedium {
+		d.cacheResult(instanceID, result)
+		return result, nil
+	}
+
+	// Default fallback
+	result := &DetectionResult{
+		Platform:   PlatformLinux,
+		Confidence: ConfidenceLow,
+		Source:     "default",
+		DetectedAt: time.Now(),
+	}
+	d.cacheResult(instanceID, result)
+	logging.LogWarn("Using default platform (Linux) for instance %s", instanceID)
+	return result, nil
+}
+
+// detectFromSSM uses SSM to detect platform
+func (d *Detector) detectFromSSM(ctx context.Context, instanceID string) (*DetectionResult, error) {
+	if d.ssmClient == nil {
+		return nil, fmt.Errorf("SSM client not available")
+	}
+
+	input := &ssm.DescribeInstanceInformationInput{
+		Filters: []ssmtypes.InstanceInformationStringFilter{
+			{
+				Key:    aws.String("InstanceIds"),
+				Values: []string{instanceID},
+			},
+		},
+	}
+
+	resp, err := d.ssmClient.DescribeInstanceInformation(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe instance information: %w", err)
+	}
+
+	if len(resp.InstanceInformationList) == 0 {
+		return nil, fmt.Errorf("no SSM information found for instance %s", instanceID)
+	}
+
+	info := resp.InstanceInformationList[0]
+	platform := d.normalizePlatform(string(info.PlatformType))
+
+	result := &DetectionResult{
+		Platform:        platform,
+		Confidence:      ConfidenceHigh,
+		Source:          "SSM",
+		DetectedAt:      time.Now(),
+		PlatformName:    aws.ToString(info.PlatformName),
+		PlatformVersion: aws.ToString(info.PlatformVersion),
+	}
+
+	logging.LogDebug("Detected platform from SSM for %s: %s (%s %s)",
+		instanceID, platform, result.PlatformName, result.PlatformVersion)
+
+	return result, nil
+}
+
+// detectFromEC2 uses EC2 metadata to detect platform
+func (d *Detector) detectFromEC2(ctx context.Context, instanceID string) (*DetectionResult, error) {
+	if d.ec2Client == nil {
+		return nil, fmt.Errorf("EC2 client not available")
+	}
+
+	input := &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
+	}
+
+	resp, err := d.ec2Client.DescribeInstances(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe instance: %w", err)
+	}
+
+	if len(resp.Reservations) == 0 || len(resp.Reservations[0].Instances) == 0 {
+		return nil, fmt.Errorf("no EC2 information found for instance %s", instanceID)
+	}
+
+	instance := resp.Reservations[0].Instances[0]
+	platformStr := string(instance.Platform)
+
+	if platformStr == "" {
+		// If platform is empty, it's likely Linux
+		platformStr = "Linux"
+	}
+
+	platform := d.normalizePlatform(platformStr)
+
+	result := &DetectionResult{
+		Platform:   platform,
+		Confidence: ConfidenceMedium,
+		Source:     "EC2",
+		DetectedAt: time.Now(),
+	}
+
+	logging.LogDebug("Detected platform from EC2 for %s: %s", instanceID, platform)
+
+	return result, nil
+}
+
+// normalizePlatform converts various platform strings to standardized Platform type
+func (d *Detector) normalizePlatform(platform string) Platform {
+	normalized := strings.ToLower(platform)
+
+	if strings.Contains(normalized, "windows") {
+		return PlatformWindows
+	}
+
+	if strings.Contains(normalized, "linux") ||
+		strings.Contains(normalized, "unix") ||
+		strings.Contains(normalized, "ubuntu") ||
+		strings.Contains(normalized, "amazon") ||
+		strings.Contains(normalized, "centos") ||
+		strings.Contains(normalized, "rhel") ||
+		strings.Contains(normalized, "debian") {
+		return PlatformLinux
+	}
+
+	if platform == "" {
+		return PlatformLinux // Default to Linux for empty platform
+	}
+
+	return PlatformUnknown
+}
+
+// getCachedResult retrieves a cached result if still valid
+func (d *Detector) getCachedResult(instanceID string) *DetectionResult {
+	d.cacheMu.RLock()
+	defer d.cacheMu.RUnlock()
+
+	result, exists := d.cache[instanceID]
+	if !exists {
+		return nil
+	}
+
+	if time.Since(result.DetectedAt) > d.cacheTTL {
+		return nil
+	}
+
+	return result
+}
+
+// cacheResult stores a detection result in cache
+func (d *Detector) cacheResult(instanceID string, result *DetectionResult) {
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
+	d.cache[instanceID] = result
+}
+
+// ClearCache clears the platform detection cache
+func (d *Detector) ClearCache() {
+	d.cacheMu.Lock()
+	defer d.cacheMu.Unlock()
+	d.cache = make(map[string]*DetectionResult)
+}
+
+// SetCacheTTL sets the cache time-to-live duration
+func (d *Detector) SetCacheTTL(ttl time.Duration) {
+	d.cacheTTL = ttl
+}

--- a/ztictl/internal/platform/detector_test.go
+++ b/ztictl/internal/platform/detector_test.go
@@ -1,0 +1,357 @@
+package platform
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockSSMClient for testing SSM operations
+type MockSSMClient struct {
+	mock.Mock
+}
+
+func (m *MockSSMClient) DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ssm.DescribeInstanceInformationOutput), args.Error(1)
+}
+
+// MockEC2Client for testing EC2 operations
+type MockEC2Client struct {
+	mock.Mock
+}
+
+func (m *MockEC2Client) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	args := m.Called(ctx, params)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*ec2.DescribeInstancesOutput), args.Error(1)
+}
+
+func TestPlatformNormalization(t *testing.T) {
+	detector := &Detector{}
+
+	tests := []struct {
+		name     string
+		input    string
+		expected Platform
+	}{
+		{"Windows Server", "Windows", PlatformWindows},
+		{"Windows lowercase", "windows", PlatformWindows},
+		{"Windows Server 2019", "Windows Server 2019", PlatformWindows},
+		{"Linux explicit", "Linux", PlatformLinux},
+		{"Linux lowercase", "linux", PlatformLinux},
+		{"Unix", "Unix", PlatformLinux},
+		{"Ubuntu", "Ubuntu", PlatformLinux},
+		{"Amazon Linux", "Amazon Linux", PlatformLinux},
+		{"CentOS", "centos", PlatformLinux},
+		{"RHEL", "rhel", PlatformLinux},
+		{"Debian", "debian", PlatformLinux},
+		{"Empty string defaults to Linux", "", PlatformLinux},
+		{"Unknown OS", "FreeBSD", PlatformUnknown},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := detector.normalizePlatform(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestDetectPlatformFromSSM(t *testing.T) {
+	ctx := context.Background()
+	instanceID := "i-1234567890abcdef0"
+
+	t.Run("Windows detection from SSM", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			&ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmtypes.InstanceInformation{
+					{
+						InstanceId:      aws.String(instanceID),
+						PlatformType:    ssmtypes.PlatformTypeWindows,
+						PlatformName:    aws.String("Microsoft Windows Server 2019 Datacenter"),
+						PlatformVersion: aws.String("10.0.17763"),
+					},
+				},
+			},
+			nil,
+		)
+
+		result, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, PlatformWindows, result.Platform)
+		assert.Equal(t, ConfidenceHigh, result.Confidence)
+		assert.Equal(t, "SSM", result.Source)
+		assert.Equal(t, "Microsoft Windows Server 2019 Datacenter", result.PlatformName)
+
+		mockSSM.AssertExpectations(t)
+	})
+
+	t.Run("Linux detection from SSM", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			&ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmtypes.InstanceInformation{
+					{
+						InstanceId:      aws.String(instanceID),
+						PlatformType:    ssmtypes.PlatformTypeLinux,
+						PlatformName:    aws.String("Amazon Linux"),
+						PlatformVersion: aws.String("2"),
+					},
+				},
+			},
+			nil,
+		)
+
+		result, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, PlatformLinux, result.Platform)
+		assert.Equal(t, ConfidenceHigh, result.Confidence)
+		assert.Equal(t, "SSM", result.Source)
+
+		mockSSM.AssertExpectations(t)
+	})
+}
+
+func TestDetectPlatformFromEC2(t *testing.T) {
+	ctx := context.Background()
+	instanceID := "i-1234567890abcdef0"
+
+	t.Run("Windows detection from EC2", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+
+		// SSM fails
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			nil,
+			assert.AnError,
+		)
+
+		// EC2 succeeds
+		windowsPlatform := ec2types.PlatformValuesWindows
+		mockEC2.On("DescribeInstances", ctx, mock.Anything).Return(
+			&ec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{
+					{
+						Instances: []ec2types.Instance{
+							{
+								InstanceId: aws.String(instanceID),
+								Platform:   windowsPlatform,
+							},
+						},
+					},
+				},
+			},
+			nil,
+		)
+
+		result, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, PlatformWindows, result.Platform)
+		assert.Equal(t, ConfidenceMedium, result.Confidence)
+		assert.Equal(t, "EC2", result.Source)
+
+		mockSSM.AssertExpectations(t)
+		mockEC2.AssertExpectations(t)
+	})
+
+	t.Run("Linux detection from EC2 (empty platform)", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+
+		// SSM fails
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			nil,
+			assert.AnError,
+		)
+
+		// EC2 succeeds with empty platform (Linux)
+		mockEC2.On("DescribeInstances", ctx, mock.Anything).Return(
+			&ec2.DescribeInstancesOutput{
+				Reservations: []ec2types.Reservation{
+					{
+						Instances: []ec2types.Instance{
+							{
+								InstanceId: aws.String(instanceID),
+								Platform:   "", // Empty platform typically means Linux
+							},
+						},
+					},
+				},
+			},
+			nil,
+		)
+
+		result, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, PlatformLinux, result.Platform)
+		assert.Equal(t, ConfidenceMedium, result.Confidence)
+		assert.Equal(t, "EC2", result.Source)
+
+		mockSSM.AssertExpectations(t)
+		mockEC2.AssertExpectations(t)
+	})
+}
+
+func TestDetectPlatformFallback(t *testing.T) {
+	ctx := context.Background()
+	instanceID := "i-1234567890abcdef0"
+
+	t.Run("Fallback to default when all APIs fail", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+
+		// Both SSM and EC2 fail
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			nil,
+			assert.AnError,
+		)
+		mockEC2.On("DescribeInstances", ctx, mock.Anything).Return(
+			nil,
+			assert.AnError,
+		)
+
+		result, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+		assert.Equal(t, PlatformLinux, result.Platform)
+		assert.Equal(t, ConfidenceLow, result.Confidence)
+		assert.Equal(t, "default", result.Source)
+
+		mockSSM.AssertExpectations(t)
+		mockEC2.AssertExpectations(t)
+	})
+}
+
+func TestCaching(t *testing.T) {
+	ctx := context.Background()
+	instanceID := "i-1234567890abcdef0"
+
+	t.Run("Cache hit prevents API calls", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+
+		// First call - APIs are invoked
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			&ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmtypes.InstanceInformation{
+					{
+						InstanceId:   aws.String(instanceID),
+						PlatformType: ssmtypes.PlatformTypeWindows,
+					},
+				},
+			},
+			nil,
+		).Once() // Important: only expect one call
+
+		// First detection
+		result1, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.Equal(t, PlatformWindows, result1.Platform)
+
+		// Second detection (should use cache)
+		result2, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.Equal(t, PlatformWindows, result2.Platform)
+
+		// Verify SSM was only called once
+		mockSSM.AssertExpectations(t)
+	})
+
+	t.Run("Cache expiry causes new API call", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+		detector.SetCacheTTL(100 * time.Millisecond) // Short TTL for testing
+
+		// Expect two calls to SSM
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			&ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmtypes.InstanceInformation{
+					{
+						InstanceId:   aws.String(instanceID),
+						PlatformType: ssmtypes.PlatformTypeLinux,
+					},
+				},
+			},
+			nil,
+		).Twice()
+
+		// First detection
+		result1, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.Equal(t, PlatformLinux, result1.Platform)
+
+		// Wait for cache to expire
+		time.Sleep(150 * time.Millisecond)
+
+		// Second detection (cache expired, should call API again)
+		result2, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.Equal(t, PlatformLinux, result2.Platform)
+
+		mockSSM.AssertExpectations(t)
+	})
+
+	t.Run("ClearCache removes all cached entries", func(t *testing.T) {
+		mockSSM := &MockSSMClient{}
+		mockEC2 := &MockEC2Client{}
+		detector := NewDetector(mockSSM, mockEC2)
+
+		// Expect two calls to SSM
+		mockSSM.On("DescribeInstanceInformation", ctx, mock.Anything).Return(
+			&ssm.DescribeInstanceInformationOutput{
+				InstanceInformationList: []ssmtypes.InstanceInformation{
+					{
+						InstanceId:   aws.String(instanceID),
+						PlatformType: ssmtypes.PlatformTypeWindows,
+					},
+				},
+			},
+			nil,
+		).Twice()
+
+		// First detection
+		result1, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.Equal(t, PlatformWindows, result1.Platform)
+
+		// Clear cache
+		detector.ClearCache()
+
+		// Second detection (cache cleared, should call API again)
+		result2, err := detector.DetectPlatform(ctx, instanceID)
+		assert.NoError(t, err)
+		assert.Equal(t, PlatformWindows, result2.Platform)
+
+		mockSSM.AssertExpectations(t)
+	})
+}

--- a/ztictl/internal/platform/interfaces.go
+++ b/ztictl/internal/platform/interfaces.go
@@ -1,0 +1,18 @@
+package platform
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+)
+
+// SSMClient interface for SSM operations
+type SSMClient interface {
+	DescribeInstanceInformation(ctx context.Context, params *ssm.DescribeInstanceInformationInput, optFns ...func(*ssm.Options)) (*ssm.DescribeInstanceInformationOutput, error)
+}
+
+// EC2Client interface for EC2 operations
+type EC2Client interface {
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+}

--- a/ztictl/internal/platform/linux_builder.go
+++ b/ztictl/internal/platform/linux_builder.go
@@ -1,0 +1,175 @@
+package platform
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// LinuxBuilder implements CommandBuilder for Linux/Unix systems
+type LinuxBuilder struct {
+	BaseBuilder
+}
+
+// NewLinuxBuilder creates a new LinuxBuilder
+func NewLinuxBuilder() *LinuxBuilder {
+	return &LinuxBuilder{}
+}
+
+// GetSSMDocument returns the SSM document for Linux
+func (b *LinuxBuilder) GetSSMDocument() string {
+	return "AWS-RunShellScript"
+}
+
+// BuildExecCommand wraps a command for execution with error handling
+func (b *LinuxBuilder) BuildExecCommand(command string) string {
+	// Execute command and capture exit code
+	return fmt.Sprintf(`
+set -e
+%s
+EXIT_CODE=$?
+echo "EXIT_CODE:$EXIT_CODE"
+exit $EXIT_CODE`, command)
+}
+
+// BuildFileExistsCommand creates a command to check if a file exists
+func (b *LinuxBuilder) BuildFileExistsCommand(path string) string {
+	safePath := b.EscapeShellArg(b.SanitizePath(path))
+	return fmt.Sprintf("test -e %s && echo 'EXISTS' || echo 'NOT_EXISTS'", safePath)
+}
+
+// BuildFileSizeCommand creates a command to get the size of a file
+func (b *LinuxBuilder) BuildFileSizeCommand(path string) string {
+	safePath := b.EscapeShellArg(b.SanitizePath(path))
+	// Use stat with portable format across different Unix systems
+	return fmt.Sprintf("stat -c '%%s' %s 2>/dev/null || stat -f '%%z' %s 2>/dev/null", safePath, safePath)
+}
+
+// BuildDirectoryCreateCommand creates a command to create a directory
+func (b *LinuxBuilder) BuildDirectoryCreateCommand(path string) string {
+	safePath := b.EscapeShellArg(b.SanitizePath(path))
+	return fmt.Sprintf("mkdir -p %s", safePath)
+}
+
+// BuildFileReadCommand creates a command to read a file (base64 encoded)
+func (b *LinuxBuilder) BuildFileReadCommand(path string) string {
+	safePath := b.EscapeShellArg(b.SanitizePath(path))
+	// Use base64 without line wrapping for easier parsing
+	return fmt.Sprintf("base64 -w 0 %s 2>/dev/null || base64 %s", safePath, safePath)
+}
+
+// BuildFileWriteCommand creates a command to write base64 data to a file
+func (b *LinuxBuilder) BuildFileWriteCommand(path string, base64Data string) string {
+	safePath := b.EscapeShellArg(b.SanitizePath(path))
+
+	// Create parent directory if it doesn't exist
+	dirPath := b.EscapeShellArg(b.SanitizePath(strings.TrimSuffix(path, "/"+filepath.Base(path))))
+
+	// Split base64 data into chunks to avoid command line length limits
+	const chunkSize = 4096
+	if len(base64Data) > chunkSize {
+		// For large data, use a here-document
+		return fmt.Sprintf(`
+mkdir -p %s
+cat << 'EOF_BASE64' | base64 -d > %s
+%s
+EOF_BASE64`, dirPath, safePath, base64Data)
+	}
+
+	// For small data, use a simple echo
+	return fmt.Sprintf(`
+mkdir -p %s
+echo '%s' | base64 -d > %s`, dirPath, base64Data, safePath)
+}
+
+// BuildFileAppendCommand creates a command to append base64 data to a file
+func (b *LinuxBuilder) BuildFileAppendCommand(path string, base64Data string) string {
+	safePath := b.EscapeShellArg(b.SanitizePath(path))
+
+	// Create parent directory if it doesn't exist
+	dirPath := b.EscapeShellArg(b.SanitizePath(strings.TrimSuffix(path, "/"+filepath.Base(path))))
+
+	// Split base64 data into chunks to avoid command line length limits
+	const chunkSize = 4096
+	if len(base64Data) > chunkSize {
+		// For large data, use a here-document
+		return fmt.Sprintf(`
+mkdir -p %s
+cat << 'EOF_BASE64' | base64 -d >> %s
+%s
+EOF_BASE64`, dirPath, safePath, base64Data)
+	}
+
+	// For small data, use a simple echo
+	return fmt.Sprintf(`
+mkdir -p %s
+echo '%s' | base64 -d >> %s`, dirPath, base64Data, safePath)
+}
+
+// NormalizePath converts a path to Unix format
+func (b *LinuxBuilder) NormalizePath(path string) string {
+	// Linux uses forward slashes
+	return strings.ReplaceAll(path, "\\", "/")
+}
+
+// ParseExitCode extracts the exit code from command output
+func (b *LinuxBuilder) ParseExitCode(output string) (int, error) {
+	// Look for our EXIT_CODE marker
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		if strings.HasPrefix(line, "EXIT_CODE:") {
+			codeStr := strings.TrimPrefix(line, "EXIT_CODE:")
+			code, err := strconv.Atoi(strings.TrimSpace(codeStr))
+			if err != nil {
+				return -1, fmt.Errorf("failed to parse exit code: %w", err)
+			}
+			return code, nil
+		}
+	}
+
+	// If no explicit exit code found, assume success if we got output
+	if output != "" {
+		return 0, nil
+	}
+
+	return -1, fmt.Errorf("no exit code found in output")
+}
+
+// ParseFileSize extracts file size from command output
+func (b *LinuxBuilder) ParseFileSize(output string) (int64, error) {
+	// Clean the output
+	sizeStr := strings.TrimSpace(output)
+
+	// Remove any error messages
+	lines := strings.Split(sizeStr, "\n")
+	if len(lines) > 0 {
+		sizeStr = lines[0]
+	}
+
+	// Parse the size
+	size, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse file size '%s': %w", sizeStr, err)
+	}
+
+	return size, nil
+}
+
+// ParseFileExists interprets command output to determine if file exists
+func (b *LinuxBuilder) ParseFileExists(output string, exitCode int) (bool, error) {
+	output = strings.TrimSpace(output)
+
+	switch output {
+	case "EXISTS":
+		return true, nil
+	case "NOT_EXISTS":
+		return false, nil
+	default:
+		// Fallback to exit code
+		if exitCode == 0 {
+			return true, nil
+		}
+		return false, nil
+	}
+}

--- a/ztictl/internal/platform/linux_builder_test.go
+++ b/ztictl/internal/platform/linux_builder_test.go
@@ -1,0 +1,413 @@
+package platform
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLinuxBuilder_GetSSMDocument(t *testing.T) {
+	builder := NewLinuxBuilder()
+	assert.Equal(t, "AWS-RunShellScript", builder.GetSSMDocument())
+}
+
+func TestLinuxBuilder_BuildExecCommand(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name     string
+		command  string
+		contains []string
+	}{
+		{
+			name:    "Simple command",
+			command: "echo hello",
+			contains: []string{
+				"echo hello",
+				"EXIT_CODE=$?",
+				"exit $EXIT_CODE",
+			},
+		},
+		{
+			name:    "Complex command with pipes",
+			command: "ps aux | grep nginx | awk '{print $2}'",
+			contains: []string{
+				"ps aux | grep nginx | awk '{print $2}'",
+				"EXIT_CODE=$?",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildExecCommand(tt.command)
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+		})
+	}
+}
+
+func TestLinuxBuilder_BuildFileExistsCommand(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name     string
+		path     string
+		contains string
+	}{
+		{
+			name:     "Simple path",
+			path:     "/tmp/test.txt",
+			contains: "test -e '/tmp/test.txt'",
+		},
+		{
+			name:     "Path with spaces",
+			path:     "/tmp/my file.txt",
+			contains: "test -e '/tmp/my file.txt'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildFileExistsCommand(tt.path)
+			assert.Contains(t, result, tt.contains)
+			assert.Contains(t, result, "EXISTS")
+			assert.Contains(t, result, "NOT_EXISTS")
+		})
+	}
+}
+
+func TestLinuxBuilder_BuildFileSizeCommand(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "Simple path",
+			path: "/tmp/test.txt",
+		},
+		{
+			name: "Path with special characters",
+			path: "/tmp/test file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildFileSizeCommand(tt.path)
+			assert.Contains(t, result, "stat")
+			assert.Contains(t, result, "%s") // Linux format
+			assert.Contains(t, result, "%z") // macOS format
+		})
+	}
+}
+
+func TestLinuxBuilder_BuildDirectoryCreateCommand(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name     string
+		path     string
+		contains string
+	}{
+		{
+			name:     "Simple directory",
+			path:     "/tmp/mydir",
+			contains: "mkdir -p '/tmp/mydir'",
+		},
+		{
+			name:     "Nested directory",
+			path:     "/tmp/a/b/c",
+			contains: "mkdir -p '/tmp/a/b/c'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildDirectoryCreateCommand(tt.path)
+			assert.Equal(t, tt.contains, result)
+		})
+	}
+}
+
+func TestLinuxBuilder_BuildFileReadCommand(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	result := builder.BuildFileReadCommand("/tmp/test.txt")
+	assert.Contains(t, result, "base64")
+	assert.Contains(t, result, "/tmp/test.txt")
+	// Should try without line wrapping first
+	assert.Contains(t, result, "-w 0")
+}
+
+func TestLinuxBuilder_BuildFileWriteCommand(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name       string
+		path       string
+		base64Data string
+		checkFor   []string
+	}{
+		{
+			name:       "Small data",
+			path:       "/tmp/test.txt",
+			base64Data: "SGVsbG8gV29ybGQ=", // "Hello World"
+			checkFor: []string{
+				"echo 'SGVsbG8gV29ybGQ='",
+				"base64 -d",
+				"> '/tmp/test.txt'",
+			},
+		},
+		{
+			name:       "Large data",
+			path:       "/tmp/test.txt",
+			base64Data: strings.Repeat("A", 5000),
+			checkFor: []string{
+				"cat << 'EOF_BASE64'",
+				"base64 -d",
+				"> '/tmp/test.txt'",
+				"EOF_BASE64",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildFileWriteCommand(tt.path, tt.base64Data)
+			for _, check := range tt.checkFor {
+				assert.Contains(t, result, check)
+			}
+		})
+	}
+}
+
+func TestLinuxBuilder_NormalizePath(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Unix path unchanged",
+			input:    "/home/user/file.txt",
+			expected: "/home/user/file.txt",
+		},
+		{
+			name:     "Windows path converted",
+			input:    "C:\\Users\\file.txt",
+			expected: "C:/Users/file.txt",
+		},
+		{
+			name:     "Mixed separators",
+			input:    "/home\\user/file.txt",
+			expected: "/home/user/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.NormalizePath(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLinuxBuilder_ParseExitCode(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name         string
+		output       string
+		expectedCode int
+		expectError  bool
+	}{
+		{
+			name:         "Successful command",
+			output:       "Command output\nEXIT_CODE:0\n",
+			expectedCode: 0,
+			expectError:  false,
+		},
+		{
+			name:         "Failed command",
+			output:       "Error message\nEXIT_CODE:1\n",
+			expectedCode: 1,
+			expectError:  false,
+		},
+		{
+			name:         "Exit code 127",
+			output:       "Command not found\nEXIT_CODE:127\n",
+			expectedCode: 127,
+			expectError:  false,
+		},
+		{
+			name:         "No exit code with output",
+			output:       "Some output",
+			expectedCode: 0,
+			expectError:  false,
+		},
+		{
+			name:         "No exit code no output",
+			output:       "",
+			expectedCode: -1,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, err := builder.ParseExitCode(tt.output)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedCode, code)
+		})
+	}
+}
+
+func TestLinuxBuilder_ParseFileSize(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name         string
+		output       string
+		expectedSize int64
+		expectError  bool
+	}{
+		{
+			name:         "Simple size",
+			output:       "1024\n",
+			expectedSize: 1024,
+			expectError:  false,
+		},
+		{
+			name:         "Large file",
+			output:       "1073741824",
+			expectedSize: 1073741824,
+			expectError:  false,
+		},
+		{
+			name:         "Size with extra output",
+			output:       "2048\nsome error message",
+			expectedSize: 2048,
+			expectError:  false,
+		},
+		{
+			name:         "Invalid size",
+			output:       "not a number",
+			expectedSize: 0,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			size, err := builder.ParseFileSize(tt.output)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedSize, size)
+		})
+	}
+}
+
+func TestLinuxBuilder_ParseFileExists(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name        string
+		output      string
+		exitCode    int
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:        "File exists",
+			output:      "EXISTS",
+			exitCode:    0,
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "File does not exist",
+			output:      "NOT_EXISTS",
+			exitCode:    1,
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "Exit code 0 fallback",
+			output:      "",
+			exitCode:    0,
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "Exit code 1 fallback",
+			output:      "",
+			exitCode:    1,
+			expected:    false,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exists, err := builder.ParseFileExists(tt.output, tt.exitCode)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, exists)
+		})
+	}
+}
+
+func TestLinuxBuilder_EscapeShellArg(t *testing.T) {
+	builder := NewLinuxBuilder()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple string",
+			input:    "hello",
+			expected: "'hello'",
+		},
+		{
+			name:     "String with spaces",
+			input:    "hello world",
+			expected: "'hello world'",
+		},
+		{
+			name:     "String with single quote",
+			input:    "it's",
+			expected: `"it's"`,
+		},
+		{
+			name:     "String with dollar sign and single quote",
+			input:    "$test's",
+			expected: `"\$test's"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.EscapeShellArg(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/ztictl/internal/platform/windows_builder.go
+++ b/ztictl/internal/platform/windows_builder.go
@@ -1,0 +1,212 @@
+package platform
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// WindowsBuilder implements CommandBuilder for Windows systems
+type WindowsBuilder struct {
+	BaseBuilder
+}
+
+// NewWindowsBuilder creates a new WindowsBuilder
+func NewWindowsBuilder() *WindowsBuilder {
+	return &WindowsBuilder{}
+}
+
+// GetSSMDocument returns the SSM document for Windows
+func (b *WindowsBuilder) GetSSMDocument() string {
+	return "AWS-RunPowerShellScript"
+}
+
+// BuildExecCommand wraps a command for execution with error handling
+func (b *WindowsBuilder) BuildExecCommand(command string) string {
+	// PowerShell command with exit code capture
+	return fmt.Sprintf(`
+$ErrorActionPreference = 'Continue'
+try {
+    %s
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -eq $null) { $exitCode = 0 }
+} catch {
+    Write-Error $_.Exception.Message
+    $exitCode = 1
+}
+Write-Output "EXIT_CODE:$exitCode"
+exit $exitCode`, command)
+}
+
+// BuildFileExistsCommand creates a command to check if a file exists
+func (b *WindowsBuilder) BuildFileExistsCommand(path string) string {
+	safePath := b.EscapePowerShellArg(b.SanitizePath(path))
+	return fmt.Sprintf(`if (Test-Path %s) { Write-Output 'EXISTS' } else { Write-Output 'NOT_EXISTS' }`, safePath)
+}
+
+// BuildFileSizeCommand creates a command to get the size of a file
+func (b *WindowsBuilder) BuildFileSizeCommand(path string) string {
+	safePath := b.EscapePowerShellArg(b.SanitizePath(path))
+	return fmt.Sprintf(`(Get-Item %s -ErrorAction SilentlyContinue).Length`, safePath)
+}
+
+// BuildDirectoryCreateCommand creates a command to create a directory
+func (b *WindowsBuilder) BuildDirectoryCreateCommand(path string) string {
+	safePath := b.EscapePowerShellArg(b.SanitizePath(path))
+	return fmt.Sprintf(`New-Item -ItemType Directory -Force -Path %s | Out-Null`, safePath)
+}
+
+// BuildFileReadCommand creates a command to read a file (base64 encoded)
+func (b *WindowsBuilder) BuildFileReadCommand(path string) string {
+	safePath := b.EscapePowerShellArg(b.SanitizePath(path))
+	// Read file as bytes and convert to base64
+	return fmt.Sprintf(`[Convert]::ToBase64String([System.IO.File]::ReadAllBytes(%s))`, safePath)
+}
+
+// BuildFileWriteCommand creates a command to write base64 data to a file
+func (b *WindowsBuilder) BuildFileWriteCommand(path string, base64Data string) string {
+	safePath := b.EscapePowerShellArg(b.SanitizePath(path))
+
+	// For large data, split into chunks to avoid command line limits
+	const chunkSize = 4096
+	if len(base64Data) > chunkSize {
+		// Use a here-string for large data
+		return fmt.Sprintf(`
+$base64 = @'
+%s
+'@
+$bytes = [Convert]::FromBase64String($base64)
+[System.IO.File]::WriteAllBytes(%s, $bytes)`, base64Data, safePath)
+	}
+
+	// For small data, use inline
+	return fmt.Sprintf(`
+$bytes = [Convert]::FromBase64String('%s')
+[System.IO.File]::WriteAllBytes(%s, $bytes)`, base64Data, safePath)
+}
+
+// BuildFileAppendCommand creates a command to append base64 data to a file
+func (b *WindowsBuilder) BuildFileAppendCommand(path string, base64Data string) string {
+	safePath := b.EscapePowerShellArg(b.SanitizePath(path))
+
+	// For large data, split into chunks to avoid command line limits
+	const chunkSize = 4096
+	if len(base64Data) > chunkSize {
+		// Use a here-string for large data
+		return fmt.Sprintf(`
+$base64 = @'
+%s
+'@
+$bytes = [Convert]::FromBase64String($base64)
+$stream = [System.IO.File]::Open(%s, [System.IO.FileMode]::Append)
+$stream.Write($bytes, 0, $bytes.Length)
+$stream.Close()`, base64Data, safePath)
+	}
+
+	// For small data, use inline
+	return fmt.Sprintf(`
+$bytes = [Convert]::FromBase64String('%s')
+$stream = [System.IO.File]::Open(%s, [System.IO.FileMode]::Append)
+$stream.Write($bytes, 0, $bytes.Length)
+$stream.Close()`, base64Data, safePath)
+}
+
+// NormalizePath converts a path to Windows format
+func (b *WindowsBuilder) NormalizePath(path string) string {
+	// Windows can use both forward and backslashes, but backslash is standard
+	// PowerShell handles both, so we'll normalize to backslash
+	normalized := strings.ReplaceAll(path, "/", "\\")
+
+	// Handle UNC paths
+	if strings.HasPrefix(normalized, "\\\\") {
+		return normalized
+	}
+
+	// Handle drive letters
+	if len(normalized) >= 2 && normalized[1] == ':' {
+		return normalized
+	}
+
+	// If path doesn't start with drive letter or UNC, assume relative
+	return normalized
+}
+
+// ParseExitCode extracts the exit code from command output
+func (b *WindowsBuilder) ParseExitCode(output string) (int, error) {
+	// Look for our EXIT_CODE marker
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "EXIT_CODE:") {
+			codeStr := strings.TrimPrefix(line, "EXIT_CODE:")
+			code, err := strconv.Atoi(strings.TrimSpace(codeStr))
+			if err != nil {
+				return -1, fmt.Errorf("failed to parse exit code: %w", err)
+			}
+			return code, nil
+		}
+	}
+
+	// If no explicit exit code found, assume success if we got output
+	if output != "" {
+		return 0, nil
+	}
+
+	return -1, fmt.Errorf("no exit code found in output")
+}
+
+// ParseFileSize extracts file size from command output
+func (b *WindowsBuilder) ParseFileSize(output string) (int64, error) {
+	// Clean the output
+	sizeStr := strings.TrimSpace(output)
+
+	// PowerShell might include newlines or carriage returns
+	sizeStr = strings.ReplaceAll(sizeStr, "\r", "")
+	lines := strings.Split(sizeStr, "\n")
+	if len(lines) > 0 {
+		sizeStr = strings.TrimSpace(lines[0])
+	}
+
+	// Parse the size
+	size, err := strconv.ParseInt(sizeStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse file size '%s': %w", sizeStr, err)
+	}
+
+	return size, nil
+}
+
+// ParseFileExists interprets command output to determine if file exists
+func (b *WindowsBuilder) ParseFileExists(output string, exitCode int) (bool, error) {
+	output = strings.TrimSpace(output)
+	output = strings.ReplaceAll(output, "\r", "")
+
+	// Check for NOT_EXISTS first since it contains "EXISTS"
+	if strings.Contains(output, "NOT_EXISTS") {
+		return false, nil
+	} else if strings.Contains(output, "EXISTS") {
+		return true, nil
+	}
+
+	// Fallback to exit code
+	if exitCode == 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// EscapePowerShellArg escapes a string for use as a PowerShell argument
+func (b *WindowsBuilder) EscapePowerShellArg(arg string) string {
+	// For PowerShell, we need to handle special characters
+	// Single quotes are the safest for literal strings
+
+	// If the argument contains single quotes, we need to escape them
+	if strings.Contains(arg, "'") {
+		// In PowerShell, double single quotes escape a single quote
+		arg = strings.ReplaceAll(arg, "'", "''")
+	}
+
+	// Wrap in single quotes
+	return fmt.Sprintf("'%s'", arg)
+}

--- a/ztictl/internal/platform/windows_builder_test.go
+++ b/ztictl/internal/platform/windows_builder_test.go
@@ -1,0 +1,442 @@
+package platform
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWindowsBuilder_GetSSMDocument(t *testing.T) {
+	builder := NewWindowsBuilder()
+	assert.Equal(t, "AWS-RunPowerShellScript", builder.GetSSMDocument())
+}
+
+func TestWindowsBuilder_BuildExecCommand(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name     string
+		command  string
+		contains []string
+	}{
+		{
+			name:    "Simple command",
+			command: "Get-Process",
+			contains: []string{
+				"Get-Process",
+				"$LASTEXITCODE",
+				"Write-Output \"EXIT_CODE:$exitCode\"",
+			},
+		},
+		{
+			name:    "Command with pipes",
+			command: "Get-Service | Where-Object {$_.Status -eq 'Running'}",
+			contains: []string{
+				"Get-Service | Where-Object {$_.Status -eq 'Running'}",
+				"$LASTEXITCODE",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildExecCommand(tt.command)
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+		})
+	}
+}
+
+func TestWindowsBuilder_BuildFileExistsCommand(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name     string
+		path     string
+		contains string
+	}{
+		{
+			name:     "Simple path",
+			path:     "C:\\temp\\test.txt",
+			contains: "Test-Path 'C:\\temp\\test.txt'",
+		},
+		{
+			name:     "Path with spaces",
+			path:     "C:\\Program Files\\test.txt",
+			contains: "Test-Path 'C:\\Program Files\\test.txt'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildFileExistsCommand(tt.path)
+			assert.Contains(t, result, tt.contains)
+			assert.Contains(t, result, "EXISTS")
+			assert.Contains(t, result, "NOT_EXISTS")
+		})
+	}
+}
+
+func TestWindowsBuilder_BuildFileSizeCommand(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name     string
+		path     string
+		contains []string
+	}{
+		{
+			name: "Simple path",
+			path: "C:\\temp\\test.txt",
+			contains: []string{
+				"Get-Item",
+				"C:\\temp\\test.txt",
+				".Length",
+			},
+		},
+		{
+			name: "UNC path",
+			path: "\\\\server\\share\\file.txt",
+			contains: []string{
+				"Get-Item",
+				"\\\\server\\share\\file.txt",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildFileSizeCommand(tt.path)
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+		})
+	}
+}
+
+func TestWindowsBuilder_BuildDirectoryCreateCommand(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name     string
+		path     string
+		contains []string
+	}{
+		{
+			name: "Simple directory",
+			path: "C:\\temp\\mydir",
+			contains: []string{
+				"New-Item",
+				"-ItemType Directory",
+				"-Force",
+				"C:\\temp\\mydir",
+			},
+		},
+		{
+			name: "Nested directory",
+			path: "C:\\temp\\a\\b\\c",
+			contains: []string{
+				"New-Item",
+				"C:\\temp\\a\\b\\c",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildDirectoryCreateCommand(tt.path)
+			for _, expected := range tt.contains {
+				assert.Contains(t, result, expected)
+			}
+		})
+	}
+}
+
+func TestWindowsBuilder_BuildFileReadCommand(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	result := builder.BuildFileReadCommand("C:\\temp\\test.txt")
+	assert.Contains(t, result, "[Convert]::ToBase64String")
+	assert.Contains(t, result, "[System.IO.File]::ReadAllBytes")
+	assert.Contains(t, result, "C:\\temp\\test.txt")
+}
+
+func TestWindowsBuilder_BuildFileWriteCommand(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name       string
+		path       string
+		base64Data string
+		checkFor   []string
+	}{
+		{
+			name:       "Small data",
+			path:       "C:\\temp\\test.txt",
+			base64Data: "SGVsbG8gV29ybGQ=", // "Hello World"
+			checkFor: []string{
+				"[Convert]::FromBase64String('SGVsbG8gV29ybGQ=')",
+				"[System.IO.File]::WriteAllBytes",
+				"C:\\temp\\test.txt",
+			},
+		},
+		{
+			name:       "Large data",
+			path:       "C:\\temp\\test.txt",
+			base64Data: strings.Repeat("A", 5000),
+			checkFor: []string{
+				"$base64 = @'",
+				"'@",
+				"[Convert]::FromBase64String($base64)",
+				"[System.IO.File]::WriteAllBytes",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.BuildFileWriteCommand(tt.path, tt.base64Data)
+			for _, check := range tt.checkFor {
+				assert.Contains(t, result, check)
+			}
+		})
+	}
+}
+
+func TestWindowsBuilder_NormalizePath(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Windows path unchanged",
+			input:    "C:\\Users\\file.txt",
+			expected: "C:\\Users\\file.txt",
+		},
+		{
+			name:     "Unix path converted",
+			input:    "C:/Users/file.txt",
+			expected: "C:\\Users\\file.txt",
+		},
+		{
+			name:     "UNC path unchanged",
+			input:    "\\\\server\\share\\file.txt",
+			expected: "\\\\server\\share\\file.txt",
+		},
+		{
+			name:     "Mixed separators",
+			input:    "C:/Users\\Documents/file.txt",
+			expected: "C:\\Users\\Documents\\file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.NormalizePath(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestWindowsBuilder_ParseExitCode(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name         string
+		output       string
+		expectedCode int
+		expectError  bool
+	}{
+		{
+			name:         "Successful command",
+			output:       "Command output\r\nEXIT_CODE:0\r\n",
+			expectedCode: 0,
+			expectError:  false,
+		},
+		{
+			name:         "Failed command",
+			output:       "Error message\r\nEXIT_CODE:1\r\n",
+			expectedCode: 1,
+			expectError:  false,
+		},
+		{
+			name:         "Exit code with spaces",
+			output:       "Some output\r\n  EXIT_CODE:127  \r\n",
+			expectedCode: 127,
+			expectError:  false,
+		},
+		{
+			name:         "No exit code with output",
+			output:       "Some output",
+			expectedCode: 0,
+			expectError:  false,
+		},
+		{
+			name:         "No exit code no output",
+			output:       "",
+			expectedCode: -1,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, err := builder.ParseExitCode(tt.output)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedCode, code)
+		})
+	}
+}
+
+func TestWindowsBuilder_ParseFileSize(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name         string
+		output       string
+		expectedSize int64
+		expectError  bool
+	}{
+		{
+			name:         "Simple size",
+			output:       "1024\r\n",
+			expectedSize: 1024,
+			expectError:  false,
+		},
+		{
+			name:         "Large file",
+			output:       "1073741824",
+			expectedSize: 1073741824,
+			expectError:  false,
+		},
+		{
+			name:         "Size with extra output",
+			output:       "2048\r\nsome error message",
+			expectedSize: 2048,
+			expectError:  false,
+		},
+		{
+			name:         "Invalid size",
+			output:       "not a number",
+			expectedSize: 0,
+			expectError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			size, err := builder.ParseFileSize(tt.output)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expectedSize, size)
+		})
+	}
+}
+
+func TestWindowsBuilder_ParseFileExists(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name        string
+		output      string
+		exitCode    int
+		expected    bool
+		expectError bool
+	}{
+		{
+			name:        "File exists",
+			output:      "EXISTS\r\n",
+			exitCode:    0,
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "File does not exist",
+			output:      "NOT_EXISTS\r\n",
+			exitCode:    1,
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "Exit code 0 fallback",
+			output:      "",
+			exitCode:    0,
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "Exit code 1 fallback",
+			output:      "",
+			exitCode:    1,
+			expected:    false,
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exists, err := builder.ParseFileExists(tt.output, tt.exitCode)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.expected, exists)
+		})
+	}
+}
+
+func TestWindowsBuilder_EscapePowerShellArg(t *testing.T) {
+	builder := NewWindowsBuilder()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Simple string",
+			input:    "hello",
+			expected: "'hello'",
+		},
+		{
+			name:     "String with spaces",
+			input:    "hello world",
+			expected: "'hello world'",
+		},
+		{
+			name:     "String with single quote",
+			input:    "it's",
+			expected: "'it''s'",
+		},
+		{
+			name:     "String with multiple quotes",
+			input:    "can't won't",
+			expected: "'can''t won''t'",
+		},
+		{
+			name:     "Path with backslashes",
+			input:    "C:\\Program Files\\app.exe",
+			expected: "'C:\\Program Files\\app.exe'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := builder.EscapePowerShellArg(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
- Added LinuxBuilder and WindowsBuilder to handle command execution, file operations, and path normalization for Linux and Windows platforms respectively.
- Implemented methods for building commands to check file existence, get file size, create directories, read and write files (including base64 encoding).
- Introduced tests for both builders to ensure correct command generation and output parsing.
- Updated SSM manager to utilize platform-specific builders for executing commands and handling file uploads/downloads.
- Enhanced error handling and output parsing for exit codes and file operations across platforms.